### PR TITLE
Expose the RequestSubscription object

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,6 @@ or Fragment lifecycle.
 
 ## Usage
 
-```groovy
-compile 'com.airbnb:rxgroups:0.2.0'
-```
-
 Start with `ObservableManager` in order to create or retrieve groups.
 
 ```java
@@ -96,6 +92,13 @@ public class MyActivity extends Activity {
   }
 }
 ```
+
+```groovy
+compile 'com.airbnb:rxgroups:0.2.1'
+```
+
+Snapshots of the development version are available in
+[Sonatype's `snapshots` repository](https://oss.sonatype.org/content/repositories/snapshots/).
 
 License
 --------

--- a/lib/src/main/java/com/airbnb/rxgroups/ObservableGroup.java
+++ b/lib/src/main/java/com/airbnb/rxgroups/ObservableGroup.java
@@ -144,8 +144,8 @@ public class ObservableGroup {
 
   /**
    * @return a {@link RequestSubscription} with which the {@link Observer} can unsubscribe
-   * from or cancel before {@link Observable}. If no {@link Observable} is found for the provided
-   * {@code tag}, {@code null} is returned instead.
+   * from or cancel before the {@link Observable} has completed. If no {@link Observable} is found
+   * for the provided {@code tag}, {@code null} is returned instead.
    */
   public RequestSubscription subscription(String tag) {
     return groupMap.get(tag);


### PR DESCRIPTION
Since `ObservableGroup.add()` is no longer in the public API, we need a way to expose the `RequestSubscription` so users can still use `cancel()` and `isCancelled()`
@elihart @SeanA208 