### PR TITLE
Use method called tag() for resubscription

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
   }
   dependencies {
     classpath 'com.bmuschko:gradle-nexus-plugin:2.3.1'
-    classpath 'com.android.tools.build:gradle:2.2.0-alpha1'
+    classpath 'com.android.tools.build:gradle:2.1.0'
     classpath 'me.tatarka.retrolambda.projectlombok:lombok.ast:0.2.3.a2'
   }
 

--- a/rxgroups-android/src/main/java/com/airbnb/rxgroups/ArrayUtils.java
+++ b/rxgroups-android/src/main/java/com/airbnb/rxgroups/ArrayUtils.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2016 Airbnb, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.airbnb.rxgroups;
 
 /**

--- a/rxgroups-android/src/main/java/com/airbnb/rxgroups/ArrayUtils.java
+++ b/rxgroups-android/src/main/java/com/airbnb/rxgroups/ArrayUtils.java
@@ -1,0 +1,111 @@
+package com.airbnb.rxgroups;
+
+/**
+ * Methods below took from commons-lang ArrayUtils
+ * https://github.com/apache/commons-lang/blob/master/src/main/java/org/apache/commons/lang3/ArrayUtils.java
+ */
+class ArrayUtils {
+  static Integer[] toObject(final int[] array) {
+    if (array == null) {
+      return null;
+    } else if (array.length == 0) {
+      return new Integer[0];
+    }
+    final Integer[] result = new Integer[array.length];
+    for (int i = 0; i < array.length; i++) {
+      result[i] = array[i];
+    }
+    return result;
+  }
+
+  static Character[] toObject(final char[] array) {
+    if (array == null) {
+      return null;
+    } else if (array.length == 0) {
+      return new Character[0];
+    }
+    final Character[] result = new Character[array.length];
+    for (int i = 0; i < array.length; i++) {
+      result[i] = array[i];
+    }
+    return result;
+  }
+
+  static Long[] toObject(final long[] array) {
+    if (array == null) {
+      return null;
+    } else if (array.length == 0) {
+      return new Long[0];
+    }
+    final Long[] result = new Long[array.length];
+    for (int i = 0; i < array.length; i++) {
+      result[i] = array[i];
+    }
+    return result;
+  }
+
+  static Short[] toObject(final short[] array) {
+    if (array == null) {
+      return null;
+    } else if (array.length == 0) {
+      return new Short[0];
+    }
+    final Short[] result = new Short[array.length];
+    for (int i = 0; i < array.length; i++) {
+      result[i] = array[i];
+    }
+    return result;
+  }
+
+  static Byte[] toObject(final byte[] array) {
+    if (array == null) {
+      return null;
+    } else if (array.length == 0) {
+      return new Byte[0];
+    }
+    final Byte[] result = new Byte[array.length];
+    for (int i = 0; i < array.length; i++) {
+      result[i] = array[i];
+    }
+    return result;
+  }
+
+  static Boolean[] toObject(final boolean[] array) {
+    if (array == null) {
+      return null;
+    } else if (array.length == 0) {
+      return new Boolean[0];
+    }
+    final Boolean[] result = new Boolean[array.length];
+    for (int i = 0; i < array.length; i++) {
+      result[i] = (array[i] ? Boolean.TRUE : Boolean.FALSE);
+    }
+    return result;
+  }
+
+  static Double[] toObject(final double[] array) {
+    if (array == null) {
+      return null;
+    } else if (array.length == 0) {
+      return new Double[0];
+    }
+    final Double[] result = new Double[array.length];
+    for (int i = 0; i < array.length; i++) {
+      result[i] = array[i];
+    }
+    return result;
+  }
+
+  static Float[] toObject(final float[] array) {
+    if (array == null) {
+      return null;
+    } else if (array.length == 0) {
+      return new Float[0];
+    }
+    final Float[] result = new Float[array.length];
+    for (int i = 0; i < array.length; i++) {
+      result[i] = array[i];
+    }
+    return result;
+  }
+}

--- a/rxgroups-android/src/main/java/com/airbnb/rxgroups/AutoResubscribe.java
+++ b/rxgroups-android/src/main/java/com/airbnb/rxgroups/AutoResubscribe.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2016 Airbnb, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.airbnb.rxgroups;
 
 import java.lang.annotation.ElementType;
@@ -12,6 +27,4 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.FIELD)
 public @interface AutoResubscribe {
-  /** The tag(s) to resubscribe to */
-  String[] value();
 }

--- a/rxgroups-android/src/main/java/com/airbnb/rxgroups/GroupLifecycleManager.java
+++ b/rxgroups-android/src/main/java/com/airbnb/rxgroups/GroupLifecycleManager.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2016 Airbnb, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.airbnb.rxgroups;
 
 import android.app.Activity;
@@ -16,6 +31,9 @@ import rx.functions.Action1;
 import rx.functions.Func1;
 import rx.subscriptions.CompositeSubscription;
 
+/**
+ * TODO
+ */
 @SuppressWarnings("WeakerAccess")
 public class GroupLifecycleManager {
   private static final String TAG = "GroupLifecycleManager";
@@ -34,20 +52,29 @@ public class GroupLifecycleManager {
     this.resubscription = resubscription;
   }
 
+  /**
+   * TODO
+   */
   public static GroupLifecycleManager onCreate(ObservableManager observableManager,
       LifecycleResubscription resubscription) {
     return onCreate(observableManager, resubscription, null, null);
   }
 
+  /**
+   * TODO
+   */
   public static GroupLifecycleManager onCreate(ObservableManager observableManager,
       @Nullable Bundle savedState, @Nullable Object target) {
     return onCreate(observableManager, new LifecycleResubscription(), savedState,
         target);
   }
 
+  /**
+   * TODO
+   */
   public static GroupLifecycleManager onCreate(ObservableManager observableManager,
-      LifecycleResubscription resubscription,
-      @Nullable Bundle savedState, @Nullable Object target) {
+      LifecycleResubscription resubscription, @Nullable Bundle savedState,
+      @Nullable Object target) {
     // Only need to resubscribe if restoring from saved state
     boolean shouldResubscribe = target != null && savedState != null;
     ObservableGroup group;
@@ -87,10 +114,16 @@ public class GroupLifecycleManager {
     return manager;
   }
 
+  /**
+   * TODO
+   */
   public ObservableGroup group() {
     return group;
   }
 
+  /**
+   * TODO
+   */
   public <T> Observable.Transformer<? super T, T> transform(String tag) {
     return group.transform(tag);
   }
@@ -153,6 +186,9 @@ public class GroupLifecycleManager {
     }
   }
 
+  /**
+   * TODO
+   */
   public void onDestroy(@Nullable Activity activity) {
     // We need to track whether the current Activity is finishing or not in order to decide if we
     // should destroy the ObservableGroup. If the Activity is not finishing, then we should not
@@ -164,15 +200,24 @@ public class GroupLifecycleManager {
     onDestroy(!hasSavedState || activity != null && activity.isFinishing());
   }
 
+  /**
+   * TODO
+   */
   public void onDestroy(Fragment fragment) {
     onDestroy(fragment.getActivity());
   }
 
+  /**
+   * TODO
+   */
   public void onResume() {
     hasSavedState = false;
     unlock();
   }
 
+  /**
+   * TODO
+   */
   public void onPause() {
     lock();
   }
@@ -185,6 +230,9 @@ public class GroupLifecycleManager {
     group.unlock();
   }
 
+  /**
+   * TODO
+   */
   public void onSaveInstanceState(Bundle outState) {
     hasSavedState = true;
     outState.putParcelable(KEY_STATE, new State(observableManager.hashCode(), group.id()));

--- a/rxgroups-android/src/main/java/com/airbnb/rxgroups/LifecycleResubscription.java
+++ b/rxgroups-android/src/main/java/com/airbnb/rxgroups/LifecycleResubscription.java
@@ -1,6 +1,23 @@
+/*
+ * Copyright (C) 2016 Airbnb, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.airbnb.rxgroups;
 
 import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -62,21 +79,42 @@ class LifecycleResubscription {
     return !qualifiedName.startsWith("android.") && !qualifiedName.startsWith("java.");
   }
 
-  private Observable<ObserverInfo> observerInfoList(Object target, Field field) {
+  private Observable<ObserverInfo> observerInfoList(final Object target, Field field) {
     final Observer<?> observer;
     try {
       observer = (Observer<?>) field.get(target);
     } catch (IllegalAccessException e) {
       throw new RuntimeException(
-          String.format("Error accessing observer %s. Make sure it's no private.", field), e);
+          String.format("Error accessing observer %s. Make sure it's not private.", field), e);
     }
 
-    return Observable.from(field.getAnnotation(AutoResubscribe.class).value())
-        .map(new Func1<String, ObserverInfo>() {
-          @Override public ObserverInfo call(String tag) {
-            return new ObserverInfo(tag, observer);
+    return Observable.just(field).flatMap(new Func1<Field, Observable<ObserverInfo>>() {
+      @Override public Observable<ObserverInfo> call(Field field) {
+        //noinspection TryWithIdenticalCatches
+        try {
+          Class<?> fieldClass = observer.getClass();
+          Method tagMethod = fieldClass.getDeclaredMethod("tag");
+          Object tag = tagMethod.invoke(observer);
+          if (tag instanceof String) {
+            return Observable.just(new ObserverInfo((String) tag, observer));
+          } else if (tag instanceof String[]) {
+            return Observable.from((String[]) tag).map(new Func1<String, ObserverInfo>() {
+              @Override public ObserverInfo call(String s) {
+                return new ObserverInfo(s, observer);
+              }
+            });
+          } else {
+            throw new RuntimeException("Method tag() must return either String or String[]");
           }
-        });
+        } catch (NoSuchMethodException e) {
+          throw new RuntimeException("Please define a method named 'tag' that returns a String", e);
+        } catch (InvocationTargetException e) {
+          throw new RuntimeException("Error accessing method tag(). Make sure it's not private", e);
+        } catch (IllegalAccessException e) {
+          throw new RuntimeException("Error accessing method tag(). Make sure it's not private", e);
+        }
+      }
+    });
   }
 
   /** Helper class to match an Observer to the Observable type it can be subscribed to. */

--- a/rxgroups-android/src/main/java/com/airbnb/rxgroups/ResubscriptionObserver.java
+++ b/rxgroups-android/src/main/java/com/airbnb/rxgroups/ResubscriptionObserver.java
@@ -1,0 +1,7 @@
+package com.airbnb.rxgroups;
+
+import rx.Observer;
+
+public interface ResubscriptionObserver<T> extends Observer<T> {
+  Object resubscriptionTag();
+}

--- a/rxgroups-android/src/main/java/com/airbnb/rxgroups/ResubscriptionObserver.java
+++ b/rxgroups-android/src/main/java/com/airbnb/rxgroups/ResubscriptionObserver.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2016 Airbnb, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.airbnb.rxgroups;
 
 import rx.Observer;

--- a/rxgroups-android/src/main/java/com/airbnb/rxgroups/Utils.java
+++ b/rxgroups-android/src/main/java/com/airbnb/rxgroups/Utils.java
@@ -1,0 +1,59 @@
+package com.airbnb.rxgroups;
+
+import java.lang.reflect.Array;
+import java.lang.reflect.GenericArrayType;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.lang.reflect.TypeVariable;
+import java.lang.reflect.WildcardType;
+
+import static com.airbnb.rxgroups.ArrayUtils.toObject;
+
+final class Utils {
+
+  static Class<?> getRawType(Type type) {
+    if (type == null) throw new NullPointerException("type == null");
+
+    if (type instanceof Class<?>) {
+      // Type is a normal class.
+      return (Class<?>) type;
+    }
+    if (type instanceof ParameterizedType) {
+      ParameterizedType parameterizedType = (ParameterizedType) type;
+
+      // I'm not exactly sure why getRawType() returns Type instead of Class. Neal isn't either but
+      // suspects some pathological case related to nested classes exists.
+      Type rawType = parameterizedType.getRawType();
+      if (!(rawType instanceof Class)) throw new IllegalArgumentException();
+      return (Class<?>) rawType;
+    }
+    if (type instanceof GenericArrayType) {
+      Type componentType = ((GenericArrayType) type).getGenericComponentType();
+      return Array.newInstance(getRawType(componentType), 0).getClass();
+    }
+    if (type instanceof TypeVariable) {
+      // We could use the variable's bounds, but that won't work if there are multiple. Having a raw
+      // type that's more general than necessary is okay.
+      return Object.class;
+    }
+    if (type instanceof WildcardType) {
+      return getRawType(((WildcardType) type).getUpperBounds()[0]);
+    }
+
+    throw new IllegalArgumentException("Expected a Class, ParameterizedType, or "
+        + "GenericArrayType, but <" + type + "> is of type " + type.getClass().getName());
+  }
+
+  static Object[] boxIfPrimitiveArray(Object object) {
+    if (object instanceof boolean[]) return toObject((boolean[]) object);
+    if (object instanceof byte[]) return toObject((byte[]) object);
+    if (object instanceof char[]) return toObject((char[]) object);
+    if (object instanceof double[]) return toObject((double[]) object);
+    if (object instanceof float[]) return toObject((float[]) object);
+    if (object instanceof int[]) return toObject((int[]) object);
+    if (object instanceof long[]) return toObject((long[]) object);
+    if (object instanceof short[]) return toObject((short[]) object);
+    if (object instanceof String[]) return (Object[]) object;
+    throw new IllegalArgumentException("Unknown array type for " + object);
+  }
+}

--- a/rxgroups-android/src/main/java/com/airbnb/rxgroups/Utils.java
+++ b/rxgroups-android/src/main/java/com/airbnb/rxgroups/Utils.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2016 Airbnb, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.airbnb.rxgroups;
 
 import java.lang.reflect.Array;

--- a/rxgroups-android/src/test/java/com/airbnb/rxgroups/LifecycleResubscriptionTest.java
+++ b/rxgroups-android/src/test/java/com/airbnb/rxgroups/LifecycleResubscriptionTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2016 Airbnb, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.airbnb.rxgroups;
 
 import com.airbnb.rxgroups.LifecycleResubscription.ObserverInfo;
@@ -16,8 +31,8 @@ public class LifecycleResubscriptionTest extends BaseTest {
   private final TestSubscriber<ObserverInfo> testSubscriber = new TestSubscriber<>();
 
   @Test public void testObservers() {
-    TestFragment testFragment = new TestFragment();
-    resubscription.observers(testFragment).subscribe(testSubscriber);
+    Foo foo = new Foo();
+    resubscription.observers(foo).subscribe(testSubscriber);
 
     testSubscriber.awaitTerminalEvent(1, TimeUnit.SECONDS);
     testSubscriber.assertValueCount(2);
@@ -25,52 +40,86 @@ public class LifecycleResubscriptionTest extends BaseTest {
     testSubscriber.assertNoErrors();
 
     assertThat(testSubscriber.getOnNextEvents()).containsOnly(
-        new ObserverInfo("Object.class", testFragment.observer1),
-        new ObserverInfo("String.class", testFragment.observer2));
+        new ObserverInfo("Object", foo.observer1),
+        new ObserverInfo("String", foo.observer2));
   }
 
   @Test public void testGetFieldsOnSuperClass() {
-    SubTestFragment subTestFragment = new SubTestFragment();
-    resubscription.observers(subTestFragment).subscribe(testSubscriber);
+    SubFoo subFoo = new SubFoo();
+    resubscription.observers(subFoo).subscribe(testSubscriber);
 
     testSubscriber.awaitTerminalEvent(1, TimeUnit.SECONDS);
     testSubscriber.assertCompleted();
     testSubscriber.assertNoErrors();
 
     assertThat(testSubscriber.getOnNextEvents()).containsOnly(
-        new ObserverInfo("Object.class", subTestFragment.observer1),
-        new ObserverInfo("String.class", subTestFragment.observer2),
-        new ObserverInfo("Integer.class", subTestFragment.foo),
-        new ObserverInfo("Long.class", subTestFragment.bar));
+        new ObserverInfo("Object", subFoo.observer1),
+        new ObserverInfo("String", subFoo.observer2),
+        new ObserverInfo("Integer", subFoo.foo),
+        new ObserverInfo("Long", subFoo.bar));
   }
 
-  @Test
-  public void testMultipleRequestsPerListener() {
-    MultiRequestTestFragment fragment = new MultiRequestTestFragment();
-    resubscription.observers(fragment).subscribe(testSubscriber);
+  @Test public void testMultipleRequestsPerListener() {
+    Bar bar = new Bar();
+    resubscription.observers(bar).subscribe(testSubscriber);
 
     testSubscriber.awaitTerminalEvent(1, TimeUnit.SECONDS);
+    testSubscriber.assertNoErrors();
     testSubscriber.assertValueCount(2);
     testSubscriber.assertCompleted();
-    testSubscriber.assertNoErrors();
 
     assertThat(testSubscriber.getOnNextEvents()).containsOnly(
-        new ObserverInfo("Class.class", fragment.baz),
-        new ObserverInfo("Double.class", fragment.baz));
+        new ObserverInfo("Class", bar.baz),
+        new ObserverInfo("Double", bar.baz));
   }
 
-  static class TestFragment {
-    @AutoResubscribe("Object.class") Observer<String> observer1 = new TestSubscriber<>();
-    @AutoResubscribe("String.class") Observer<String> observer2 = new TestSubscriber<>();
+  @Test public void testTagMethodHasWrongReturnType() {
+    Baz baz = new Baz();
+    resubscription.observers(baz).subscribe(testSubscriber);
+
+    testSubscriber.awaitTerminalEvent(1, TimeUnit.SECONDS);
+    testSubscriber.assertError(RuntimeException.class);
   }
 
-  private static class SubTestFragment extends TestFragment {
-    @AutoResubscribe("Integer.class") Observer<String> foo = new TestSubscriber<>();
-    @AutoResubscribe("Long.class") Observer<String> bar = new TestSubscriber<>();
+  static class Foo {
+    @AutoResubscribe Observer<String> observer1 = new TestSubscriber<String>() {
+      String tag() {
+        return "Object";
+      }
+    };
+    @AutoResubscribe Observer<String> observer2 = new TestSubscriber<String>() {
+      String tag() {
+        return "String";
+      }
+    };
   }
 
-  private static class MultiRequestTestFragment {
-    @AutoResubscribe({ "Class.class", "Double.class" }) Observer<String> baz =
-        new TestSubscriber<>();
+  private static class SubFoo extends Foo {
+    @AutoResubscribe Observer<String> foo = new TestSubscriber<String>() {
+      String tag() {
+        return "Integer";
+      }
+    };
+    @AutoResubscribe Observer<String> bar = new TestSubscriber<String>() {
+      String tag() {
+        return "Long";
+      }
+    };
+  }
+
+  private static class Bar {
+    @AutoResubscribe Observer<String> baz = new TestSubscriber<String>() {
+      String[] tag() {
+        return new String[] {"Class", "Double" };
+      }
+    };
+  }
+
+  private static class Baz {
+    @AutoResubscribe Observer<String> lol = new TestSubscriber<String>() {
+      int tag() {
+        return 2;
+      }
+    };
   }
 }

--- a/sample/src/main/java/com/airbnb/rxgroups/MainActivity.java
+++ b/sample/src/main/java/com/airbnb/rxgroups/MainActivity.java
@@ -27,7 +27,6 @@ import android.widget.TextView;
 import android.widget.Toast;
 
 import rx.Observable;
-import rx.Observer;
 import rx.android.schedulers.AndroidSchedulers;
 
 public class MainActivity extends AppCompatActivity {
@@ -41,7 +40,12 @@ public class MainActivity extends AppCompatActivity {
   private boolean isRunning;
   private boolean isLocked;
 
-  @AutoResubscribe final Observer<Long> observer = new Observer<Long>() {
+  @AutoResubscribe
+  final ResubscriptionObserver<Long> observer = new ResubscriptionObserver<Long>() {
+    @Override public Object resubscriptionTag() {
+      return OBSERVABLE_TAG;
+    }
+
     @Override public void onCompleted() {
       Log.d(TAG, "onCompleted()");
     }
@@ -53,10 +57,6 @@ public class MainActivity extends AppCompatActivity {
     @Override public void onNext(Long l) {
       Log.d(TAG, "Current Thread=" + Thread.currentThread().getName() + ", onNext()=" + l);
       output.setText(output.getText() + " " + l);
-    }
-
-    public String tag() {
-      return OBSERVABLE_TAG;
     }
   };
   private Drawable alarmOffDrawable;

--- a/sample/src/main/java/com/airbnb/rxgroups/MainActivity.java
+++ b/sample/src/main/java/com/airbnb/rxgroups/MainActivity.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2016 Airbnb, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.airbnb.rxgroups;
 
 import android.graphics.drawable.Drawable;
@@ -26,7 +41,7 @@ public class MainActivity extends AppCompatActivity {
   private boolean isRunning;
   private boolean isLocked;
 
-  @AutoResubscribe(OBSERVABLE_TAG) final Observer<Long> observer = new Observer<Long>() {
+  @AutoResubscribe final Observer<Long> observer = new Observer<Long>() {
     @Override public void onCompleted() {
       Log.d(TAG, "onCompleted()");
     }
@@ -38,6 +53,10 @@ public class MainActivity extends AppCompatActivity {
     @Override public void onNext(Long l) {
       Log.d(TAG, "Current Thread=" + Thread.currentThread().getName() + ", onNext()=" + l);
       output.setText(output.getText() + " " + l);
+    }
+
+    public String tag() {
+      return OBSERVABLE_TAG;
     }
   };
   private Drawable alarmOffDrawable;

--- a/sample/src/main/java/com/airbnb/rxgroups/SampleApplication.java
+++ b/sample/src/main/java/com/airbnb/rxgroups/SampleApplication.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2016 Airbnb, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.airbnb.rxgroups;
 
 import android.app.Application;

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,1 @@
-include ':rxgroups', ':sample', ':rxgroups-android'
+include ':rxgroups', ':rxgroups-android', ':sample'


### PR DESCRIPTION
Establish a convention that the Observer should have a method called
`tag()` that returns either a `String` or a `String[]` and returns
the tag associated to that Observer. This way we can have the
flexibility of determining the correct tag at runtime.