### PR TITLE
Tentative fix for Activity recreated after finish

### DIFF
--- a/rxgroups-android/src/main/java/com/airbnb/rxgroups/GroupLifecycleManager.java
+++ b/rxgroups-android/src/main/java/com/airbnb/rxgroups/GroupLifecycleManager.java
@@ -182,6 +182,9 @@ public class GroupLifecycleManager {
     // being destroyed and are not ever coming back. However, this isn't perfect, especially
     // when using fragments in a ViewPager. We might want to allow users to explicitly destroy it
     // instead, in order to mitigate this issue.
+    // Also in some situations it seems like an Activity can be recreated even though its
+    // isFinishing() property is set to true. For this reason, we must also check
+    // isChangingConfigurations() to make sure it's safe to destroy the group.
     onDestroy(!hasSavedState
         || (activity != null && activity.isFinishing() && !activity.isChangingConfigurations()));
   }

--- a/rxgroups-android/src/main/java/com/airbnb/rxgroups/GroupLifecycleManager.java
+++ b/rxgroups-android/src/main/java/com/airbnb/rxgroups/GroupLifecycleManager.java
@@ -182,7 +182,8 @@ public class GroupLifecycleManager {
     // being destroyed and are not ever coming back. However, this isn't perfect, especially
     // when using fragments in a ViewPager. We might want to allow users to explicitly destroy it
     // instead, in order to mitigate this issue.
-    onDestroy(!hasSavedState || activity != null && activity.isFinishing());
+    onDestroy(!hasSavedState
+        || (activity != null && activity.isFinishing() && !activity.isChangingConfigurations()));
   }
 
   /** Call this method from your Activity or Fragment's onDestroy method */


### PR DESCRIPTION
In some situations it seems like an Activity can be recreated even
though its `isFinishing()` property is set to true. Sounds like we can
also check `isChangingConfigurations()` to make sure it's safe to
destroy the group.

@elihart 