### PR TITLE
Bump buildTools, sdkVersion and dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,8 @@ android:
   components:
   - tools
   - platform-tools
-  - build-tools-23.0.2
-  - android-23
+  - build-tools-24.0.2
+  - android-24
   - extra-google-google_play_services
   - extra-android-m2repository
   - extra-android-support

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
   }
   dependencies {
     classpath 'com.bmuschko:gradle-nexus-plugin:2.3.1'
-    classpath 'com.android.tools.build:gradle:2.1.0'
+    classpath 'com.android.tools.build:gradle:2.1.3'
     classpath 'me.tatarka.retrolambda.projectlombok:lombok.ast:0.2.3.a2'
   }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Tue Sep 15 12:05:54 PDT 2015
+#Sat Aug 27 18:56:48 PDT 2016
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.13-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip

--- a/rxgroups-android/build.gradle
+++ b/rxgroups-android/build.gradle
@@ -2,18 +2,18 @@ apply plugin: 'com.android.library'
 apply from: 'gradle-maven-push.gradle'
 
 android {
-  compileSdkVersion 23
-  buildToolsVersion "23.0.2"
+  compileSdkVersion 24
+  buildToolsVersion "24.0.2"
 
   defaultConfig {
     minSdkVersion 16
-    targetSdkVersion 23
+    targetSdkVersion 24
   }
 }
 
 dependencies {
   compile project(':rxgroups')
-  compile 'io.reactivex:rxandroid:1.2.0'
+  compile 'io.reactivex:rxandroid:1.2.1'
 
   testCompile "junit:junit:4.12"
   testCompile 'org.mockito:mockito-core:1.10.19'
@@ -21,7 +21,7 @@ dependencies {
   testCompile "org.hamcrest:hamcrest-core:1.3"
   testCompile "org.hamcrest:hamcrest-library:1.3"
   testCompile 'org.assertj:assertj-core:1.7.0'
-  testCompile("org.robolectric:robolectric:3.0") {
+  testCompile("org.robolectric:robolectric:3.1.2") {
     exclude module: 'classworlds'
     exclude module: 'commons-logging'
     exclude module: 'httpclient'

--- a/rxgroups/build.gradle
+++ b/rxgroups/build.gradle
@@ -15,7 +15,7 @@ project.group = GROUP
 project.version = VERSION_NAME
 
 dependencies {
-  compile 'io.reactivex:rxjava:1.1.5'
+  compile 'io.reactivex:rxjava:1.1.9'
   compile 'com.google.code.findbugs:jsr305:3.0.0'
 
   testCompile 'junit:junit:4.12'

--- a/rxgroups/src/test/java/com/airbnb/rxgroups/ObservableGroupTest.java
+++ b/rxgroups/src/test/java/com/airbnb/rxgroups/ObservableGroupTest.java
@@ -19,7 +19,6 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.io.IOException;
-import java.util.Collections;
 
 import rx.Observable;
 import rx.Observer;
@@ -218,14 +217,13 @@ public class ObservableGroupTest {
     subject.onNext("Hello World");
     subject.onCompleted();
 
-    assertThat(testObserver.getOnCompletedEvents()).isEmpty();
-    assertThat(testObserver.getOnNextEvents()).isEmpty();
+    testObserver.assertNotCompleted();
+    testObserver.assertNoValues();
 
     group.<String>observable("foo").subscribe(testObserver);
 
     testObserver.assertCompleted();
-    assertThat(testObserver.getOnNextEvents())
-        .isEqualTo(Collections.singletonList("Hello World"));
+    testObserver.assertValue("Hello World");
     assertThat(group.hasObservable("foo")).isEqualTo(false);
   }
 
@@ -419,7 +417,7 @@ public class ObservableGroupTest {
 
     testObserver.assertTerminalEvent();
     testObserver.assertNoErrors();
-    testObserver.assertReceivedOnNext(Collections.singletonList("Chespirito"));
+    testObserver.assertValue("Chespirito");
     assertThat(group.hasObservable("tag")).isEqualTo(false);
   }
 

--- a/rxgroups/src/test/java/com/airbnb/rxgroups/TestObserver.java
+++ b/rxgroups/src/test/java/com/airbnb/rxgroups/TestObserver.java
@@ -1,0 +1,280 @@
+package com.airbnb.rxgroups;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import rx.Notification;
+import rx.Observer;
+import rx.exceptions.CompositeException;
+
+class TestObserver<T> implements Observer<T> {
+  private final Observer<T> delegate;
+  private final List<T> onNextEvents = new ArrayList<T>();
+  private final List<Throwable> onErrorEvents = new ArrayList<Throwable>();
+  private final List<Notification<T>> onCompletedEvents = new ArrayList<>();
+  private final CountDownLatch latch = new CountDownLatch(1);
+
+  TestObserver(Observer<T> delegate) {
+    this.delegate = delegate;
+  }
+
+  @SuppressWarnings("unchecked") TestObserver() {
+    this.delegate = (Observer<T>) INERT;
+  }
+
+  @Override public void onCompleted() {
+    try {
+      onCompletedEvents.add(Notification.<T>createOnCompleted());
+      delegate.onCompleted();
+    } finally {
+      latch.countDown();
+    }
+  }
+
+  /**
+   * Get the {@link Notification}s representing each time this observer was notified of sequence
+   * completion via {@link #onCompleted}, as a {@link List}.
+   *
+   * @return a list of Notifications representing calls to this observer's {@link #onCompleted}
+   * method
+   */
+  List<Notification<T>> getOnCompletedEvents() {
+    return Collections.unmodifiableList(onCompletedEvents);
+  }
+
+  @Override public void onError(Throwable e) {
+    try {
+      onErrorEvents.add(e);
+      delegate.onError(e);
+    } finally {
+      latch.countDown();
+    }
+  }
+
+  /**
+   * Get the {@link Throwable}s this observer was notified of via {@link #onError} as a {@link
+   * List}.
+   *
+   * @return a list of Throwables passed to this observer's {@link #onError} method
+   */
+  private List<Throwable> getOnErrorEvents() {
+    return Collections.unmodifiableList(onErrorEvents);
+  }
+
+  @Override public void onNext(T t) {
+    onNextEvents.add(t);
+    delegate.onNext(t);
+  }
+
+  /**
+   * Get the sequence of items observed by this observer, as an ordered {@link List}.
+   *
+   * @return a list of items observed by this observer, in the order in which they were observed
+   */
+  List<T> getOnNextEvents() {
+    return Collections.unmodifiableList(onNextEvents);
+  }
+
+  /**
+   * Get a list containing all of the items and notifications received by this observer, where the
+   * items will be given as-is, any error notifications will be represented by their {@code
+   * Throwable}s, and any sequence-complete notifications will be represented by their {@code
+   * Notification} objects.
+   *
+   * @return a {@link List} containing one item for each item or notification received by this
+   * observer, in the order in which they were observed or received
+   */
+  List<Object> getEvents() {
+    ArrayList<Object> events = new ArrayList<>();
+    events.add(onNextEvents);
+    events.add(onErrorEvents);
+    events.add(onCompletedEvents);
+    return Collections.unmodifiableList(events);
+  }
+
+  /**
+   * Assert that a particular sequence of items was received in order.
+   *
+   * @param items the sequence of items expected to have been observed
+   * @throws AssertionError if the sequence of items observed does not exactly match {@code items}
+   */
+  void assertReceivedOnNext(List<T> items) {
+    if (onNextEvents.size() != items.size()) {
+      assertionError("Number of items does not match. Provided: " + items.size() + "  Actual: "
+          + onNextEvents.size()
+          + ".\n"
+          + "Provided values: " + items
+          + "\n"
+          + "Actual values: " + onNextEvents
+          + "\n");
+    }
+
+    for (int i = 0; i < items.size(); i++) {
+      T expected = items.get(i);
+      T actual = onNextEvents.get(i);
+      if (expected == null) {
+        // check for null equality
+        if (actual != null) {
+          assertionError("Value at index: " + i + " expected to be [null] but was: [" + actual
+              + "]\n");
+        }
+      } else if (!expected.equals(actual)) {
+        assertionError("Value at index: " + i
+            + " expected to be [" + expected + "] (" + expected.getClass().getSimpleName()
+            + ") but was: [" + actual + "] ("
+            + (actual != null ? actual.getClass().getSimpleName() : "null") + ")\n");
+
+      }
+    }
+
+  }
+
+  /**
+   * Assert that a single terminal event occurred, either {@link #onCompleted} or {@link #onError}.
+   *
+   * @throws AssertionError if not exactly one terminal event notification was received
+   */
+  void assertTerminalEvent() {
+    if (onErrorEvents.size() > 1) {
+      assertionError("Too many onError events: " + onErrorEvents.size());
+    }
+
+    if (onCompletedEvents.size() > 1) {
+      assertionError("Too many onCompleted events: " + onCompletedEvents.size());
+    }
+
+    if (onCompletedEvents.size() == 1 && onErrorEvents.size() == 1) {
+      assertionError("Received both an onError and onCompleted. Should be one or the other.");
+    }
+
+    if (onCompletedEvents.isEmpty() && onErrorEvents.isEmpty()) {
+      assertionError("No terminal events received.");
+    }
+  }
+
+  void assertCompleted() {
+    int s = onCompletedEvents.size();
+    if (s == 0) {
+      assertionError("Not completed!");
+    } else if (s > 1) {
+      assertionError("Completed multiple times: " + s);
+    }
+  }
+
+  void assertNoErrors() {
+    List<Throwable> onErrorEvents = getOnErrorEvents();
+    if (!onErrorEvents.isEmpty()) {
+      assertionError("Unexpected onError events");
+    }
+  }
+
+  void assertNotCompleted() {
+    int s = onCompletedEvents.size();
+    if (s == 1) {
+      assertionError("Completed!");
+    } else if (s > 1) {
+      assertionError("Completed multiple times: " + s);
+    }
+  }
+
+  void assertValues(T... values) {
+    assertReceivedOnNext(Arrays.asList(values));
+  }
+
+  void assertValue(T value) {
+    assertReceivedOnNext(Collections.singletonList(value));
+  }
+
+  void assertNoValues() {
+    int s = getOnNextEvents().size();
+    if (s != 0) {
+      assertionError("No onNext events expected yet some received: " + s);
+    }
+  }
+
+  void awaitTerminalEvent(long timeout, TimeUnit unit) {
+    try {
+      latch.await(timeout, unit);
+    } catch (InterruptedException e) {
+      throw new IllegalStateException("Interrupted", e);
+    }
+  }
+
+  void assertError(Class<? extends Throwable> clazz) {
+    List<Throwable> err = getOnErrorEvents();
+    if (err.isEmpty()) {
+      assertionError("No errors");
+    } else if (err.size() > 1) {
+      AssertionError ae = new AssertionError("Multiple errors: " + err.size());
+      ae.initCause(new CompositeException(err));
+      throw ae;
+    } else if (!clazz.isInstance(err.get(0))) {
+      AssertionError ae = new AssertionError("Exceptions differ; expected: " + clazz + ", actual: "
+          + err.get(0));
+      ae.initCause(err.get(0));
+      throw ae;
+    }
+  }
+
+  /**
+   * Combines an assertion error message with the current completion and error state of this
+   * TestSubscriber, giving more information when some assertXXX check fails.
+   *
+   * @param message the message to use for the error
+   */
+  private void assertionError(String message) {
+    StringBuilder b = new StringBuilder(message.length() + 32);
+
+    b.append(message)
+        .append(" (");
+
+    int c = onCompletedEvents.size();
+    b.append(c)
+        .append(" completion");
+    if (c != 1) {
+      b.append('s');
+    }
+    b.append(')');
+
+    if (!onErrorEvents.isEmpty()) {
+      int size = onErrorEvents.size();
+      b.append(" (+")
+          .append(size)
+          .append(" error");
+      if (size != 1) {
+        b.append('s');
+      }
+      b.append(')');
+    }
+
+    AssertionError ae = new AssertionError(b.toString());
+    if (!onErrorEvents.isEmpty()) {
+      if (onErrorEvents.size() == 1) {
+        ae.initCause(onErrorEvents.get(0));
+      } else {
+        ae.initCause(new CompositeException(onErrorEvents));
+      }
+    }
+    throw ae;
+  }
+
+  // do nothing ... including swallowing errors
+  private static final Observer<Object> INERT = new Observer<Object>() {
+    @Override public void onCompleted() {
+      // deliberately ignored
+    }
+
+    @Override public void onError(Throwable e) {
+      // deliberately ignored
+    }
+
+    @Override public void onNext(Object t) {
+      // deliberately ignored
+    }
+
+  };
+}

--- a/rxgroups/src/test/java/com/airbnb/rxgroups/TestObserver.java
+++ b/rxgroups/src/test/java/com/airbnb/rxgroups/TestObserver.java
@@ -13,8 +13,8 @@ import rx.exceptions.CompositeException;
 
 class TestObserver<T> implements Observer<T> {
   private final Observer<T> delegate;
-  private final List<T> onNextEvents = new ArrayList<T>();
-  private final List<Throwable> onErrorEvents = new ArrayList<Throwable>();
+  private final List<T> onNextEvents = new ArrayList<>();
+  private final List<Throwable> onErrorEvents = new ArrayList<>();
   private final List<Notification<T>> onCompletedEvents = new ArrayList<>();
   private final CountDownLatch latch = new CountDownLatch(1);
 
@@ -275,6 +275,5 @@ class TestObserver<T> implements Observer<T> {
     @Override public void onNext(Object t) {
       // deliberately ignored
     }
-
   };
 }

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -26,7 +26,7 @@ android {
 dependencies {
   compile project(':rxgroups-android')
   compile 'io.reactivex:rxandroid:1.2.0'
-  compile 'com.android.support:appcompat-v7:23.4.0'
-  compile 'com.android.support:design:23.4.0'
+  compile 'com.android.support:appcompat-v7:24.2.0'
+  compile 'com.android.support:design:24.2.0'
   testCompile 'junit:junit:4.12'
 }

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -1,13 +1,13 @@
 apply plugin: 'com.android.application'
 
 android {
-  compileSdkVersion 23
-  buildToolsVersion "23.0.2"
+  compileSdkVersion 24
+  buildToolsVersion "24.0.2"
 
   defaultConfig {
     applicationId "com.airbnb.rxgroups"
     minSdkVersion 16
-    targetSdkVersion 23
+    targetSdkVersion 24
     versionCode 1
     versionName "1.0"
   }


### PR DESCRIPTION
Test changes were required since RxJava 1.1.6 changed the way
`ReplaySubject` works in a way that broke reusing the same `TestSubscriber` more
than once. (See comments here: https://github.com/ReactiveX/RxJava/pull/4225#issuecomment-242952697)
Fixed tests by using a `TestObserver` that can be reused multiple times.

@elihart 