### PR TITLE
Use Observable.fromAsync() instead of create()

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
   }
   dependencies {
     classpath 'com.bmuschko:gradle-nexus-plugin:2.3.1'
-    classpath 'com.android.tools.build:gradle:2.1.3'
+    classpath 'com.android.tools.build:gradle:2.2.0-beta3'
     classpath 'me.tatarka.retrolambda.projectlombok:lombok.ast:0.2.3.a2'
   }
 


### PR DESCRIPTION
The version of `create()` we were using did not handle backpressure and
it not recommended. This is slightly safer as it will handle that
correctly.

@elihart 