### PR TITLE
Make ObservableGroup#resubscribe visible to generated code, artificat for rx-processor

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,6 +18,10 @@ subprojects {
   group = GROUP
   version = VERSION_NAME
 
+  tasks.withType(Javadoc) {
+    options.addStringOption('Xdoclint:none', '-quiet')
+  }
+
   if (!project.name.equals('rxgroups-processor')) {
     apply plugin: 'checkstyle'
 

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -7,6 +7,9 @@ def versions = [
 
 ext.isCi = (project.hasProperty('CI') && CI == 'true')
 
+ext.repositoryUrl = 'https://oss.sonatype.org/service/local/staging/deploy/maven2/'
+ext.snapshotRepositoryUrl = 'https://oss.sonatype.org/content/repositories/snapshots/'
+
 ext.androidConfig = [
         compileSdkVersion: 25,
         buildToolsVersion: '25.0.2',

--- a/rxgroups-processor/build.gradle
+++ b/rxgroups-processor/build.gradle
@@ -1,4 +1,5 @@
 apply plugin: 'java'
+apply plugin: 'com.bmuschko.nexus'
 
 targetCompatibility = JavaVersion.VERSION_1_7
 sourceCompatibility = JavaVersion.VERSION_1_7
@@ -9,3 +10,14 @@ dependencies {
     compile project(':rxgroups')
 }
 
+extraArchive {
+    sources = true
+    tests = false
+    javadoc = false
+}
+
+nexus {
+    sign = !project.ext.isCi
+    repositoryUrl = project.ext.repositoryUrl
+    snapshotRepositoryUrl = project.ext.snapshotRepositoryUrl
+}

--- a/rxgroups-processor/src/main/java/com/airbnb/rxgroups/processor/ResubscriptionProcessor.java
+++ b/rxgroups-processor/src/main/java/com/airbnb/rxgroups/processor/ResubscriptionProcessor.java
@@ -197,7 +197,7 @@ public class ResubscriptionProcessor extends AbstractProcessor {
 
     for (String observerName : info.observerNames) {
       String tag = info.originalClassName.getSimpleName().toString() + "_" + observerName;
-      builder.addStatement("target.$L.tag = $S", observerName, tag);
+      builder.addStatement("target.$L.setTag($S)", observerName, tag);
       builder.addStatement("group.resubscribe(target.$L)", observerName);
     }
 

--- a/rxgroups-processor/src/main/java/com/airbnb/rxgroups/processor/ResubscriptionProcessor.java
+++ b/rxgroups-processor/src/main/java/com/airbnb/rxgroups/processor/ResubscriptionProcessor.java
@@ -2,6 +2,7 @@ package com.airbnb.rxgroups.processor;
 
 import com.airbnb.rxgroups.AutoResubscribe;
 import com.airbnb.rxgroups.AutoResubscribingObserver;
+import com.airbnb.rxgroups.BaseObservableResubscriber;
 import com.airbnb.rxgroups.ObservableGroup;
 import com.google.auto.service.AutoService;
 import com.google.common.collect.ImmutableSet;
@@ -13,6 +14,7 @@ import com.squareup.javapoet.TypeName;
 import com.squareup.javapoet.TypeSpec;
 
 import java.io.IOException;
+import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -177,6 +179,7 @@ public class ResubscriptionProcessor extends AbstractProcessor {
 
   private void generateClass(ClassToGenerateInfo info) throws IOException {
     TypeSpec generatedClass = TypeSpec.classBuilder(info.generatedClassName)
+            .superclass(BaseObservableResubscriber.class)
             .addJavadoc("Generated file. Do not modify!")
             .addModifiers(Modifier.PUBLIC)
             .addMethod(generateConstructor(info))
@@ -197,7 +200,7 @@ public class ResubscriptionProcessor extends AbstractProcessor {
 
     for (String observerName : info.observerNames) {
       String tag = info.originalClassName.getSimpleName().toString() + "_" + observerName;
-      builder.addStatement("target.$L.setTag($S)", observerName, tag);
+      builder.addStatement("setTag(target.$L, $S)", observerName, tag);
       builder.addStatement("group.resubscribe(target.$L)", observerName);
     }
 

--- a/rxgroups/build.gradle
+++ b/rxgroups/build.gradle
@@ -65,6 +65,6 @@ extraArchive {
 
 nexus {
   sign = !project.ext.isCi
-  repositoryUrl = 'https://oss.sonatype.org/service/local/staging/deploy/maven2/'
-  snapshotRepositoryUrl = 'https://oss.sonatype.org/content/repositories/snapshots/'
+  repositoryUrl = project.ext.repositoryUrl
+  snapshotRepositoryUrl = project.ext.snapshotRepositoryUrl
 }

--- a/rxgroups/src/main/java/com/airbnb/rxgroups/AutoResubscribingObserver.java
+++ b/rxgroups/src/main/java/com/airbnb/rxgroups/AutoResubscribingObserver.java
@@ -4,20 +4,34 @@ package com.airbnb.rxgroups;
 import rx.Observer;
 
 public abstract class AutoResubscribingObserver<T> implements Observer<T> {
-    public String tag;
 
-    @Override
-    public void onCompleted() {
+  private String tag;
 
-    }
+  public String getTag() {
+    return tag;
+  }
 
-    @Override
-    public void onError(Throwable e) {
+  /**
+   * Sets this observer's resubscription {@code tag}.
+   * This is automatically done when using the {@link AutoResubscribe} annotation.
+   */
+  public void setTag(String tag) {
+    this.tag = tag;
+  }
 
-    }
+  @Override
+  public void onCompleted() {
 
-    @Override
-    public void onNext(T t) {
+  }
 
-    }
+  @Override
+  public void onError(Throwable e) {
+
+  }
+
+  @Override
+  public void onNext(T t) {
+
+  }
+
 }

--- a/rxgroups/src/main/java/com/airbnb/rxgroups/AutoResubscribingObserver.java
+++ b/rxgroups/src/main/java/com/airbnb/rxgroups/AutoResubscribingObserver.java
@@ -11,11 +11,7 @@ public abstract class AutoResubscribingObserver<T> implements Observer<T> {
     return tag;
   }
 
-  /**
-   * Sets this observer's resubscription {@code tag}.
-   * This is automatically done when using the {@link AutoResubscribe} annotation.
-   */
-  public void setTag(String tag) {
+  void setTag(String tag) {
     this.tag = tag;
   }
 

--- a/rxgroups/src/main/java/com/airbnb/rxgroups/AutoResubscribingObserver.java
+++ b/rxgroups/src/main/java/com/airbnb/rxgroups/AutoResubscribingObserver.java
@@ -4,7 +4,7 @@ package com.airbnb.rxgroups;
 import rx.Observer;
 
 public abstract class AutoResubscribingObserver<T> implements Observer<T> {
-    String tag;
+    public String tag;
 
     @Override
     public void onCompleted() {

--- a/rxgroups/src/main/java/com/airbnb/rxgroups/BaseObservableResubscriber.java
+++ b/rxgroups/src/main/java/com/airbnb/rxgroups/BaseObservableResubscriber.java
@@ -1,0 +1,9 @@
+package com.airbnb.rxgroups;
+
+public class BaseObservableResubscriber {
+
+  protected void setTag(AutoResubscribingObserver target, String tag) {
+    target.setTag(tag);
+  }
+
+}

--- a/rxgroups/src/main/java/com/airbnb/rxgroups/ObservableGroup.java
+++ b/rxgroups/src/main/java/com/airbnb/rxgroups/ObservableGroup.java
@@ -85,7 +85,7 @@ public class ObservableGroup {
 
     private Map<String, ManagedObservable<?>> getObservablesForObserver(
             AutoResubscribingObserver<?> observer) {
-        return getObservablesForObserver(observer.tag);
+        return getObservablesForObserver(observer.getTag());
     }
 
     private Map<String, ManagedObservable<?>> getObservablesForObserver(String observerTag) {
@@ -104,12 +104,12 @@ public class ObservableGroup {
      */
     public <T> Observable.Transformer<? super T, T> transform(AutoResubscribingObserver<? super
             T> observer, String observableTag) {
-        return new GroupSubscriptionTransformer<>(this, observer.tag, observableTag);
+        return new GroupSubscriptionTransformer<>(this, observer.getTag(), observableTag);
     }
 
     public <T> Observable.Transformer<? super T, T> transform(AutoResubscribingObserver<? super
             T> observer) {
-        return new GroupSubscriptionTransformer<>(this, observer.tag, null);
+        return new GroupSubscriptionTransformer<>(this, observer.getTag(), null);
     }
 
     /**
@@ -199,12 +199,12 @@ public class ObservableGroup {
     public <T> Observable<T> observable(AutoResubscribingObserver<? super T> observer, String
             observableTag) {
         checkNotDestroyed();
-        Map<String, ManagedObservable<?>> observables = getObservablesForObserver(observer.tag);
+        Map<String, ManagedObservable<?>> observables = getObservablesForObserver(observer.getTag());
         //noinspection unchecked
         ManagedObservable<T> managedObservable = (ManagedObservable<T>) observables.get(
                 observableTag);
         if (managedObservable == null) {
-            throw new IllegalStateException("No observable exists for observer: " + observer.tag
+            throw new IllegalStateException("No observable exists for observer: " + observer.getTag()
                     + " and observable: " + observableTag);
         }
 
@@ -241,11 +241,11 @@ public class ObservableGroup {
      * nothing happens.
      */
     public void cancelAndRemove(AutoResubscribingObserver<?> observer, String observableTag) {
-        cancelAndRemove(observer.tag, observableTag);
+        cancelAndRemove(observer.getTag(), observableTag);
     }
 
     public void cancelAndRemove(AutoResubscribingObserver<?> observer) {
-        cancelAndRemove(observer.tag, null);
+        cancelAndRemove(observer.getTag(), null);
     }
 
     public void cancelAllObservablesForObserver(AutoResubscribingObserver<?> observer) {

--- a/rxgroups/src/main/java/com/airbnb/rxgroups/ObservableGroup.java
+++ b/rxgroups/src/main/java/com/airbnb/rxgroups/ObservableGroup.java
@@ -199,13 +199,14 @@ public class ObservableGroup {
     public <T> Observable<T> observable(AutoResubscribingObserver<? super T> observer, String
             observableTag) {
         checkNotDestroyed();
-        Map<String, ManagedObservable<?>> observables = getObservablesForObserver(observer.getTag());
+        Map<String, ManagedObservable<?>> observables
+            = getObservablesForObserver(observer.getTag());
         //noinspection unchecked
         ManagedObservable<T> managedObservable = (ManagedObservable<T>) observables.get(
                 observableTag);
         if (managedObservable == null) {
-            throw new IllegalStateException("No observable exists for observer: " + observer.getTag()
-                    + " and observable: " + observableTag);
+            throw new IllegalStateException("No observable exists for observer: "
+                + observer.getTag() + " and observable: " + observableTag);
         }
 
         Observable<T> observable = managedObservable.observable();

--- a/rxgroups/src/main/java/com/airbnb/rxgroups/ObservableGroup.java
+++ b/rxgroups/src/main/java/com/airbnb/rxgroups/ObservableGroup.java
@@ -228,7 +228,7 @@ public class ObservableGroup {
         return subscription(observer, null);
     }
 
-    <T> void resubscribe(AutoResubscribingObserver<? super T> observer) {
+    public <T> void resubscribe(AutoResubscribingObserver<? super T> observer) {
         Map<String, ManagedObservable<?>> observables = getObservablesForObserver(observer);
         for (String observableTag : observables.keySet()) {
             observable(observer, observableTag).subscribe(observer);

--- a/rxgroups/src/main/java/com/airbnb/rxgroups/TestAutoResubscribingObserver.java
+++ b/rxgroups/src/main/java/com/airbnb/rxgroups/TestAutoResubscribingObserver.java
@@ -3,6 +3,6 @@ package com.airbnb.rxgroups;
 
 class TestAutoResubscribingObserver extends AutoResubscribingObserver<String> {
   TestAutoResubscribingObserver(String tag) {
-    this.tag = tag;
+    this.setTag(tag);
   }
 }

--- a/rxgroups/src/test/java/com/airbnb/rxgroups/ObservableGroupTest.java
+++ b/rxgroups/src/test/java/com/airbnb/rxgroups/ObservableGroupTest.java
@@ -49,7 +49,7 @@ public class ObservableGroupTest {
     ObservableGroup group2 = observableManager.newGroup();
     Observable<String> observable = Observable.never();
 
-    group.add(fooObserver.tag, null, observable, new TestObserver<>());
+    group.add(fooObserver.getTag(), null, observable, new TestObserver<>());
 
     assertThat(group.hasObservables(fooObserver)).isEqualTo(true);
     assertThat(group2.hasObservables(fooObserver)).isEqualTo(false);
@@ -59,13 +59,13 @@ public class ObservableGroupTest {
   @Test public void shouldNotBeCompleted() {
     ObservableGroup group = observableManager.newGroup();
     TestObserver<Object> subscriber = new TestObserver<>();
-    group.add(fooObserver.tag, null, Observable.never(), subscriber);
+    group.add(fooObserver.getTag(), null, Observable.never(), subscriber);
     subscriber.assertNotCompleted();
   }
 
   @Test public void shouldBeSubscribed() {
     ObservableGroup group = observableManager.newGroup();
-    group.add(fooObserver.tag, null, Observable.never(), new TestObserver<>());
+    group.add(fooObserver.getTag(), null, Observable.never(), new TestObserver<>());
     assertThat(group.subscription(fooObserver).isCancelled()).isEqualTo(false);
   }
 
@@ -74,7 +74,7 @@ public class ObservableGroupTest {
     PublishSubject<String> subject = PublishSubject.create();
     TestObserver<String> subscriber = new TestObserver<>();
 
-    group.add(fooObserver.tag, null, subject, subscriber);
+    group.add(fooObserver.getTag(), null, subject, subscriber);
     subscriber.assertNotCompleted();
 
     subject.onNext("Foo Bar");
@@ -88,7 +88,7 @@ public class ObservableGroupTest {
     ObservableGroup group = observableManager.newGroup();
     TestObserver<String> testObserver = new TestObserver<>();
     Observable<String> observable = Observable.error(new RuntimeException("boom"));
-    group.add(fooObserver.tag, null, observable, testObserver);
+    group.add(fooObserver.getTag(), null, observable, testObserver);
 
     testObserver.assertError(RuntimeException.class);
   }
@@ -101,13 +101,13 @@ public class ObservableGroupTest {
     TestObserver<String> subscriber1 = new TestObserver<>();
     TestObserver<String> subscriber2 = new TestObserver<>();
 
-    group.add(barObserver.tag, null, observable1, subscriber1);
+    group.add(barObserver.getTag(), null, observable1, subscriber1);
     assertThat(group.hasObservables(barObserver)).isEqualTo(true);
     assertThat(group.hasObservables(fooObserver)).isEqualTo(false);
     assertThat(group2.hasObservables(barObserver)).isEqualTo(false);
     assertThat(group2.hasObservables(fooObserver)).isEqualTo(false);
 
-    group2.add(fooObserver.tag, null, observable2, subscriber2);
+    group2.add(fooObserver.getTag(), null, observable2, subscriber2);
     assertThat(group.hasObservables(barObserver)).isEqualTo(true);
     assertThat(group.hasObservables(fooObserver)).isEqualTo(false);
     assertThat(group2.hasObservables(barObserver)).isEqualTo(false);
@@ -121,8 +121,8 @@ public class ObservableGroupTest {
     Observable<String> observable2 = Observable.never();
     TestObserver<String> subscriber1 = new TestObserver<>();
 
-    group.add(fooObserver.tag, null, observable1, subscriber1);
-    group2.add(fooObserver.tag, null, observable2, subscriber1);
+    group.add(fooObserver.getTag(), null, observable1, subscriber1);
+    group2.add(fooObserver.getTag(), null, observable2, subscriber1);
 
     observableManager.destroy(group);
 
@@ -145,8 +145,8 @@ public class ObservableGroupTest {
     TestObserver<String> subscriber1 = new TestObserver<>();
     TestObserver<String> subscriber2 = new TestObserver<>();
 
-    group.add(fooObserver.tag, null, observable1, subscriber1);
-    group.add(barObserver.tag, null, observable2, subscriber2);
+    group.add(fooObserver.getTag(), null, observable1, subscriber1);
+    group.add(barObserver.getTag(), null, observable2, subscriber2);
 
     group.unsubscribe();
     observableManager.destroy(group);
@@ -160,7 +160,7 @@ public class ObservableGroupTest {
     PublishSubject<String> subject = PublishSubject.create();
     TestObserver<String> subscriber1 = new TestObserver<>();
 
-    group.add(fooObserver.tag, null, subject, subscriber1);
+    group.add(fooObserver.getTag(), null, subject, subscriber1);
     group.unsubscribe();
     subject.onNext("Hello");
     subject.onCompleted();
@@ -173,7 +173,7 @@ public class ObservableGroupTest {
     ObservableGroup group = observableManager.newGroup();
     PublishSubject<String> subject = PublishSubject.create();
     TestObserver<String> subscriber = new TestObserver<>();
-    group.add(fooObserver.tag, null, subject, subscriber);
+    group.add(fooObserver.getTag(), null, subject, subscriber);
 
     subject.onNext("Roberto Gomez Bolanos is king");
     subject.onCompleted();
@@ -187,7 +187,7 @@ public class ObservableGroupTest {
     TestObserver<String> testObserver = new TestObserver<>();
     PublishSubject<String> subject = PublishSubject.create();
 
-    group.add(fooObserver.tag, null, subject, testObserver);
+    group.add(fooObserver.getTag(), null, subject, testObserver);
 
     subject.onError(new RuntimeException("BOOM!"));
 
@@ -201,7 +201,7 @@ public class ObservableGroupTest {
     TestObserver<String> testObserver = new TestObserver<>();
     PublishSubject<String> subject = PublishSubject.create();
 
-    group.add(fooObserver.tag, null, subject, testObserver);
+    group.add(fooObserver.getTag(), null, subject, testObserver);
     group.unsubscribe();
 
     subject.onNext("Roberto Gomez Bolanos");
@@ -215,7 +215,7 @@ public class ObservableGroupTest {
     ObservableGroup group = observableManager.newGroup();
     TestObserver<String> testObserver = new TestObserver<>();
     PublishSubject<String> subject = PublishSubject.create();
-    group.add(fooObserver.tag, null, subject, testObserver);
+    group.add(fooObserver.getTag(), null, subject, testObserver);
     group.unsubscribe();
 
     subject.onNext("Hello World");
@@ -236,7 +236,7 @@ public class ObservableGroupTest {
     TestObserver<String> testObserver = new TestObserver<>();
     PublishSubject<String> subject = PublishSubject.create();
 
-    group.add(fooObserver.tag, null, subject, testObserver);
+    group.add(fooObserver.getTag(), null, subject, testObserver);
     group.unsubscribe();
 
     subject.onError(new Exception("Exploded"));
@@ -255,7 +255,7 @@ public class ObservableGroupTest {
     ObservableGroup group = observableManager.newGroup();
     TestObserver<String> testObserver = new TestObserver<>();
     PublishSubject<String> subject = PublishSubject.create();
-    group.add(fooObserver.tag, null, subject, testObserver);
+    group.add(fooObserver.getTag(), null, subject, testObserver);
     group.unsubscribe();
 
     subject.onNext("Hello World");
@@ -281,7 +281,7 @@ public class ObservableGroupTest {
     PublishSubject<String> subject = PublishSubject.create();
     TestObserver<String> testObserver = new TestObserver<>();
 
-    group2.add(fooObserver.tag, null, subject, testObserver);
+    group2.add(fooObserver.getTag(), null, subject, testObserver);
     group.unsubscribe();
 
     subject.onNext("Gremio Foot-ball Porto Alegrense");
@@ -299,7 +299,7 @@ public class ObservableGroupTest {
     PublishSubject<String> subject = PublishSubject.create();
     TestObserver<String> testObserver = new TestObserver<>();
 
-    group.add(fooObserver.tag, null, subject, testObserver);
+    group.add(fooObserver.getTag(), null, subject, testObserver);
     observableManager.destroy(group);
 
     subject.onNext("Gremio Foot-ball Porto Alegrense");
@@ -317,8 +317,8 @@ public class ObservableGroupTest {
     PublishSubject<String> subject2 = PublishSubject.create();
     TestObserver<String> testSubscriber2 = new TestObserver<>();
 
-    group.add(fooObserver.tag, null, subject1, testSubscriber1);
-    group2.add(barObserver.tag, null, subject2, testSubscriber2);
+    group.add(fooObserver.getTag(), null, subject1, testSubscriber1);
+    group2.add(barObserver.getTag(), null, subject2, testSubscriber2);
     group.unsubscribe();
 
     subject1.onNext("Florinda Mesa");
@@ -337,7 +337,7 @@ public class ObservableGroupTest {
     TestObserver<String> testSubscriber1 = new TestObserver<>();
     TestObserver<String> testSubscriber2 = new TestObserver<>();
 
-    group.add(fooObserver.tag, null, subject, testSubscriber1);
+    group.add(fooObserver.getTag(), null, subject, testSubscriber1);
     group.observable(fooObserver).subscribe(testSubscriber2);
 
     subject.onNext("Ruben Aguirre");
@@ -356,8 +356,8 @@ public class ObservableGroupTest {
     PublishSubject<String> subject2 = PublishSubject.create();
     TestObserver<String> testSubscriber2 = new TestObserver<>();
 
-    group.add(fooObserver.tag, null, subject1, testSubscriber1);
-    group.add(barObserver.tag, null, subject2, testSubscriber2);
+    group.add(fooObserver.getTag(), null, subject1, testSubscriber1);
+    group.add(barObserver.getTag(), null, subject2, testSubscriber2);
     group.unsubscribe();
 
     subject1.onNext("Chespirito");
@@ -377,7 +377,7 @@ public class ObservableGroupTest {
     PublishSubject<String> subject = PublishSubject.create();
 
     group.lock();
-    group.add(fooObserver.tag, null, subject, testObserver);
+    group.add(fooObserver.getTag(), null, subject, testObserver);
 
     subject.onNext("Chespirito");
     subject.onCompleted();
@@ -393,7 +393,7 @@ public class ObservableGroupTest {
     PublishSubject<String> subject = PublishSubject.create();
 
     group.lock();
-    group.add(fooObserver.tag, null, subject, testObserver);
+    group.add(fooObserver.getTag(), null, subject, testObserver);
 
     subject.onNext("Chespirito");
     subject.onCompleted();
@@ -411,7 +411,7 @@ public class ObservableGroupTest {
     TestObserver<String> testObserver = new TestObserver<>();
     PublishSubject<String> subject = PublishSubject.create();
 
-    group.add(fooObserver.tag, null, subject, testObserver);
+    group.add(fooObserver.getTag(), null, subject, testObserver);
     group.lock();
 
     subject.onNext("Chespirito");
@@ -430,7 +430,7 @@ public class ObservableGroupTest {
     TestObserver<String> testObserver = new TestObserver<>();
     PublishSubject<String> subject = PublishSubject.create();
 
-    group.add(fooObserver.tag, null, subject, testObserver);
+    group.add(fooObserver.getTag(), null, subject, testObserver);
     group.lock();
     group.unsubscribe();
 
@@ -448,7 +448,7 @@ public class ObservableGroupTest {
     ObservableGroup group = observableManager.newGroup();
     group.destroy();
     try {
-      group.add(fooObserver.tag, null, PublishSubject.<String>create(), new TestObserver<>());
+      group.add(fooObserver.getTag(), null, PublishSubject.<String>create(), new TestObserver<>());
       fail();
     } catch (IllegalStateException ignored) {
     }
@@ -457,7 +457,7 @@ public class ObservableGroupTest {
   @Test public void testResubscribeThrowsAfterDestroyed() {
     ObservableGroup group = observableManager.newGroup();
     try {
-      group.add(fooObserver.tag, null, PublishSubject.<String>create(), new TestObserver<>());
+      group.add(fooObserver.getTag(), null, PublishSubject.<String>create(), new TestObserver<>());
       group.unsubscribe();
       group.destroy();
       group.observable(fooObserver).subscribe(new TestObserver<>());
@@ -472,8 +472,8 @@ public class ObservableGroupTest {
     PublishSubject<String> observable2 = PublishSubject.create();
     TestObserver<String> observer1 = new TestObserver<>();
     TestObserver<String> observer2 = new TestObserver<>();
-    group.add(fooObserver.tag, null, observable1, observer1);
-    group.add(fooObserver.tag, null, observable2, observer2);
+    group.add(fooObserver.getTag(), null, observable1, observer1);
+    group.add(fooObserver.getTag(), null, observable2, observer2);
 
     assertThat(group.subscription(fooObserver).isCancelled()).isEqualTo(false);
     assertThat(group.hasObservables(fooObserver)).isEqualTo(true);
@@ -487,14 +487,14 @@ public class ObservableGroupTest {
 
   @Test public void testCancelAndReAddSubscription() {
     ObservableGroup group = observableManager.newGroup();
-    group.add(fooObserver.tag, null, PublishSubject.<String>create(), new TestObserver<>());
+    group.add(fooObserver.getTag(), null, PublishSubject.<String>create(), new TestObserver<>());
     group.cancelAndRemove(fooObserver);
     assertThat(group.subscription(fooObserver)).isNull();
 
     Observable<String> observable = PublishSubject.create();
     Observer<String> observer = new TestObserver<>();
 
-    group.add(fooObserver.tag, null, observable, observer);
+    group.add(fooObserver.getTag(), null, observable, observer);
 
     assertThat(group.subscription(fooObserver).isCancelled()).isFalse();
   }


### PR DESCRIPTION
+ remove deprecated use `Observable.create`
+ add bmuschko to rxgroups-processor (@felipecsl I haven't used this before, so lmk if it seems okay)
+ Made tag in `AutoResubscribeObserver`, and `ObservableGroup#resubscribe` public. This fixes a bug where any class that does not have the package `com.airbnb.rxgroups` does not compile.

I don't love making `tag` public, but the other option is generating all code under `com.airbnb.rxgroups` which feels wrong.

We could create some sort of hacky getter/setter that requires some special private class which is  added to the generated code. Worth it? other ideas?