### PR TITLE
Make mulitiple observer support more clear

### DIFF
--- a/rxgroups-android/src/main/java/com/airbnb/rxgroups/GroupLifecycleManager.java
+++ b/rxgroups-android/src/main/java/com/airbnb/rxgroups/GroupLifecycleManager.java
@@ -136,7 +136,7 @@ public class GroupLifecycleManager {
   }
 
   public void cancelAndRemove(String observableTag) {
-    group.cancelAndRemove(observableTag);
+    group.cancelAndRemoveAllWithTag(observableTag);
   }
 
   public void cancelAllObservablesForObserver(AutoResubscribingObserver<?> observer) {

--- a/rxgroups-android/src/main/java/com/airbnb/rxgroups/GroupLifecycleManager.java
+++ b/rxgroups-android/src/main/java/com/airbnb/rxgroups/GroupLifecycleManager.java
@@ -123,22 +123,25 @@ public class GroupLifecycleManager {
   }
 
   /**
-   * Cancel the given request if it is running, so that no future request callbacks are received.
-   * If the request is not running then nothing
-   * happens.
+   * Calls {@link ObservableGroup#cancelAndRemove(AutoResubscribingObserver)} for the group
+   * associated with this instance.
    */
   public void cancelAndRemove(AutoResubscribingObserver<?> observer) {
     group.cancelAndRemove(observer);
   }
 
+  /**
+   * Calls {@link ObservableGroup#cancelAndRemove(AutoResubscribingObserver, String)} for the group
+   * associated with this instance.
+   */
   public void cancelAndRemove(AutoResubscribingObserver<?> observer, String observableTag) {
     group.cancelAndRemove(observer, observableTag);
   }
 
-  public void cancelAndRemove(String observableTag) {
-    group.cancelAndRemoveAllWithTag(observableTag);
-  }
-
+  /**
+   * Calls {@link ObservableGroup#cancelAllObservablesForObserver(AutoResubscribingObserver)}
+   * for the group associated with this instance.
+   */
   public void cancelAllObservablesForObserver(AutoResubscribingObserver<?> observer) {
     group.cancelAllObservablesForObserver(observer);
   }

--- a/rxgroups-android/src/main/java/com/airbnb/rxgroups/GroupLifecycleManager.java
+++ b/rxgroups-android/src/main/java/com/airbnb/rxgroups/GroupLifecycleManager.java
@@ -109,10 +109,6 @@ public class GroupLifecycleManager {
     return group.hasObservable(observer, observableTag);
   }
 
-  public boolean hasObservable(String observableTag) {
-    return group.hasObservable(observableTag);
-  }
-
   /**
    * Subscribe all Observer fields on the target that are annotated with {@link AutoResubscribe}
    * and that have their corresponding Observable in flight.

--- a/rxgroups-android/src/main/java/com/airbnb/rxgroups/GroupLifecycleManager.java
+++ b/rxgroups-android/src/main/java/com/airbnb/rxgroups/GroupLifecycleManager.java
@@ -109,6 +109,10 @@ public class GroupLifecycleManager {
     return group.hasObservable(observer, observableTag);
   }
 
+  public boolean hasObservable(String observableTag) {
+    return group.hasObservable(observableTag);
+  }
+
   /**
    * Subscribe all Observer fields on the target that are annotated with {@link AutoResubscribe}
    * and that have their corresponding Observable in flight.
@@ -129,6 +133,10 @@ public class GroupLifecycleManager {
 
   public void cancelAndRemove(AutoResubscribingObserver<?> observer, String observableTag) {
     group.cancelAndRemove(observer, observableTag);
+  }
+
+  public void cancelAndRemove(String observableTag) {
+    group.cancelAndRemove(observableTag);
   }
 
   public void cancelAllObservablesForObserver(AutoResubscribingObserver<?> observer) {

--- a/rxgroups/src/main/java/com/airbnb/rxgroups/ObservableGroup.java
+++ b/rxgroups/src/main/java/com/airbnb/rxgroups/ObservableGroup.java
@@ -34,7 +34,7 @@ import rx.functions.Action1;
  * ready. If the {@link ObservableGroup} is locked when the response arrives, or if the observer was
  * removed, the response will be queued and delivered when the {@link ObservableGroup} is unlocked
  * and a observer is added. <p> Each {@link AutoResubscribingObserver} can only be subscribed to
- * the same observable tag once. If a {@link AutoResubscribingObserver} is already subscribed the
+ * the same observable tag once. If a {@link AutoResubscribingObserver} is already subscribed then
  * the given tag, the original subscription will be cancelled and discarded.
  */
 public class ObservableGroup {
@@ -114,7 +114,7 @@ public class ObservableGroup {
      * automatically added to this {@link ObservableGroup}. <p> Convenience method
      * for {@link #transform(AutoResubscribingObserver, String)} when {@code observer} only
      * is subscribed to one {@link Observable}. {@link AutoResubscribingObserver#getTag()}
-     * will be used the {@code tag}.
+     * will be used {@code tag}.
      */
     public <T> Observable.Transformer<? super T, T> transform(AutoResubscribingObserver<? super
         T> observer) {
@@ -147,8 +147,8 @@ public class ObservableGroup {
 
     private List<String> observerTagsForObservableTag(String observableTag) {
         List<String> observerTags = new ArrayList<>();
-        for (Map.Entry<String, Map<String, ManagedObservable<?>>> groupEntry
-            : groupMap.entrySet()) {
+        for (Map.Entry<String, Map<String, ManagedObservable<?>>> groupEntry :
+          groupMap.entrySet()) {
             String observerTag = groupEntry.getKey();
             Map<String, ManagedObservable<?>> observables = groupEntry.getValue();
             if (observables.containsKey(observableTag)) {
@@ -208,7 +208,8 @@ public class ObservableGroup {
     }
 
     /**
-     * Returns an existing {@link Observable} for the provided {@code tag}.
+     * Returns an existing {@link Observable} for the .
+     *
      * <p> Does not change the locked status of this {@link ObservableGroup}.
      * If it is unlocked, and the Observable has already emitted events,
      * they will be immediately delivered. If it is locked then no events will be
@@ -350,10 +351,10 @@ public class ObservableGroup {
      * Returns whether there exists any observable with given {@code observableTag}.
      */
     public boolean hasObservable(String observableTag) {
-        for (String observerTag: observerTagsForObservableTag(observableTag)) {
-             if (subscription(observerTag, observableTag) != null) {
-                 return true;
-             }
+        for (String observerTag : observerTagsForObservableTag(observableTag)) {
+            if (subscription(observerTag, observableTag) != null) {
+                return true;
+            }
         }
         return false;
     }

--- a/rxgroups/src/main/java/com/airbnb/rxgroups/ObservableGroup.java
+++ b/rxgroups/src/main/java/com/airbnb/rxgroups/ObservableGroup.java
@@ -32,7 +32,7 @@ import rx.functions.Action1;
  * ready. If the {@link ObservableGroup} is locked when the response arrives, or if the observer was
  * removed, the response will be queued and delivered when the {@link ObservableGroup} is unlocked
  * and a observer is added. <p> Each {@link AutoResubscribingObserver} can only be subscribed to
- * the same observable tag once. If a {@link AutoResubscribingObserver} is already subscribed then
+ * the same observable tag once. If a {@link AutoResubscribingObserver} is already subscribed to
  * the given tag, the original subscription will be cancelled and discarded.
  */
 public class ObservableGroup {

--- a/rxgroups/src/main/java/com/airbnb/rxgroups/ObservableGroup.java
+++ b/rxgroups/src/main/java/com/airbnb/rxgroups/ObservableGroup.java
@@ -305,19 +305,6 @@ public class ObservableGroup {
         cancelAndRemove(observer.getTag(), observer.getTag());
     }
 
-    /**
-     * Removes all {@link Observable} with {@code observableTag} from this group
-     * and cancels all of its subscriptions.
-     * No more events will be delivered to any {@link AutoResubscribingObserver} associated with
-     * {@code observableTag}.
-     * If no Observables are found for the provided {@code observableTag}, nothing happens.
-     */
-    public void cancelAndRemoveAllWithTag(String observableTag) {
-        for (String observerTag: observerTagsForObservableTag(observableTag)) {
-            cancelAndRemove(observerTag, observableTag);
-        }
-    }
-
     public void cancelAllObservablesForObserver(AutoResubscribingObserver<?> observer) {
         Map<String, ManagedObservable<?>> observables = getObservablesForObserver(observer);
         for (ManagedObservable<?> managedObservable : observables.values()) {
@@ -345,18 +332,6 @@ public class ObservableGroup {
      */
     public boolean hasObservable(AutoResubscribingObserver<?> observer, String observableTag) {
         return subscription(observer, observableTag) != null;
-    }
-
-    /**
-     * Returns whether there exists any observable with given {@code observableTag}.
-     */
-    public boolean hasObservable(String observableTag) {
-        for (String observerTag : observerTagsForObservableTag(observableTag)) {
-            if (subscription(observerTag, observableTag) != null) {
-                return true;
-            }
-        }
-        return false;
     }
 
     public boolean hasObservables(AutoResubscribingObserver<?> observer) {

--- a/rxgroups/src/main/java/com/airbnb/rxgroups/ObservableGroup.java
+++ b/rxgroups/src/main/java/com/airbnb/rxgroups/ObservableGroup.java
@@ -70,7 +70,7 @@ public class ObservableGroup {
         }
 
         ManagedObservable<T> managedObservable =
-                new ManagedObservable<>(observableTag, observableTag, observable, observer, new
+                new ManagedObservable<>(observerTag, observableTag, observable, observer, new
                         Action0() {
                             @Override
                             public void call() {
@@ -90,11 +90,11 @@ public class ObservableGroup {
         return getObservablesForObserver(observer.getTag());
     }
 
-    private Map<String, ManagedObservable<?>> getObservablesForObserver(String observableTag) {
-        Map<String, ManagedObservable<?>> map = groupMap.get(observableTag);
+    private Map<String, ManagedObservable<?>> getObservablesForObserver(String observerTag) {
+        Map<String, ManagedObservable<?>> map = groupMap.get(observerTag);
         if (map == null) {
             map = new HashMap<>();
-            groupMap.put(observableTag, map);
+            groupMap.put(observerTag, map);
         }
         return map;
     }
@@ -105,8 +105,8 @@ public class ObservableGroup {
      * subscribed to.
      */
     public <T> Observable.Transformer<? super T, T> transform(AutoResubscribingObserver<? super
-            T> observer, String tag) {
-        return new GroupSubscriptionTransformer<>(this, observer.getTag(), tag);
+            T> observer, String observableTag) {
+        return new GroupSubscriptionTransformer<>(this, observer.getTag(), observableTag);
     }
 
     /**
@@ -215,7 +215,7 @@ public class ObservableGroup {
      * delivered until it is unlocked.
      */
     public <T> Observable<T> observable(AutoResubscribingObserver<? super T> observer) {
-        return observable(observer, null);
+        return observable(observer, observer.getTag());
     }
 
     public <T> Observable<T> observable(AutoResubscribingObserver<? super T> observer, String

--- a/rxgroups/src/main/java/com/airbnb/rxgroups/ObservableGroup.java
+++ b/rxgroups/src/main/java/com/airbnb/rxgroups/ObservableGroup.java
@@ -15,9 +15,7 @@
  */
 package com.airbnb.rxgroups;
 
-import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -143,19 +141,6 @@ public class ObservableGroup {
                 action.call(managedObservable);
             }
         }
-    }
-
-    private List<String> observerTagsForObservableTag(String observableTag) {
-        List<String> observerTags = new ArrayList<>();
-        for (Map.Entry<String, Map<String, ManagedObservable<?>>> groupEntry :
-          groupMap.entrySet()) {
-            String observerTag = groupEntry.getKey();
-            Map<String, ManagedObservable<?>> observables = groupEntry.getValue();
-            if (observables.containsKey(observableTag)) {
-                observerTags.add(observerTag);
-            }
-        }
-        return observerTags;
     }
 
     /**

--- a/rxgroups/src/main/java/com/airbnb/rxgroups/ObservableGroup.java
+++ b/rxgroups/src/main/java/com/airbnb/rxgroups/ObservableGroup.java
@@ -147,11 +147,12 @@ public class ObservableGroup {
 
     private List<String> observerTagsForObservableTag(String observableTag) {
         List<String> observerTags = new ArrayList<>();
-        for (Map.Entry<String, Map<String, ManagedObservable<?>>> groupEntry : groupMap.entrySet()) {
+        for (Map.Entry<String, Map<String, ManagedObservable<?>>> groupEntry
+            : groupMap.entrySet()) {
             String observerTag = groupEntry.getKey();
             Map<String, ManagedObservable<?>> observables = groupEntry.getValue();
             if (observables.containsKey(observableTag)) {
-               observerTags.add(observerTag);
+                observerTags.add(observerTag);
             }
         }
         return observerTags;

--- a/rxgroups/src/test/java/com/airbnb/rxgroups/ObservableGroupTest.java
+++ b/rxgroups/src/test/java/com/airbnb/rxgroups/ObservableGroupTest.java
@@ -74,7 +74,7 @@ public class ObservableGroupTest {
     PublishSubject<String> subject = PublishSubject.create();
     TestObserver<String> subscriber = new TestObserver<>();
 
-    group.add(fooObserver.getTag(), null, subject, subscriber);
+    group.add(fooObserver.getTag(), fooObserver.getTag(), subject, subscriber);
     subscriber.assertNotCompleted();
 
     subject.onNext("Foo Bar");
@@ -88,7 +88,7 @@ public class ObservableGroupTest {
     ObservableGroup group = observableManager.newGroup();
     TestObserver<String> testObserver = new TestObserver<>();
     Observable<String> observable = Observable.error(new RuntimeException("boom"));
-    group.add(fooObserver.getTag(), null, observable, testObserver);
+    group.add(fooObserver.getTag(), fooObserver.getTag(), observable, testObserver);
 
     testObserver.assertError(RuntimeException.class);
   }
@@ -145,8 +145,8 @@ public class ObservableGroupTest {
     TestObserver<String> subscriber1 = new TestObserver<>();
     TestObserver<String> subscriber2 = new TestObserver<>();
 
-    group.add(fooObserver.getTag(), null, observable1, subscriber1);
-    group.add(barObserver.getTag(), null, observable2, subscriber2);
+    group.add(fooObserver.getTag(), fooObserver.getTag(), observable1, subscriber1);
+    group.add(barObserver.getTag(), barObserver.getTag(), observable2, subscriber2);
 
     group.unsubscribe();
     observableManager.destroy(group);
@@ -160,7 +160,7 @@ public class ObservableGroupTest {
     PublishSubject<String> subject = PublishSubject.create();
     TestObserver<String> subscriber1 = new TestObserver<>();
 
-    group.add(fooObserver.getTag(), null, subject, subscriber1);
+    group.add(fooObserver.getTag(), fooObserver.getTag(), subject, subscriber1);
     group.unsubscribe();
     subject.onNext("Hello");
     subject.onCompleted();
@@ -173,7 +173,7 @@ public class ObservableGroupTest {
     ObservableGroup group = observableManager.newGroup();
     PublishSubject<String> subject = PublishSubject.create();
     TestObserver<String> subscriber = new TestObserver<>();
-    group.add(fooObserver.getTag(), null, subject, subscriber);
+    group.add(fooObserver.getTag(), fooObserver.getTag(), subject, subscriber);
 
     subject.onNext("Roberto Gomez Bolanos is king");
     subject.onCompleted();
@@ -187,7 +187,7 @@ public class ObservableGroupTest {
     TestObserver<String> testObserver = new TestObserver<>();
     PublishSubject<String> subject = PublishSubject.create();
 
-    group.add(fooObserver.getTag(), null, subject, testObserver);
+    group.add(fooObserver.getTag(), fooObserver.getTag(), subject, testObserver);
 
     subject.onError(new RuntimeException("BOOM!"));
 
@@ -201,7 +201,7 @@ public class ObservableGroupTest {
     TestObserver<String> testObserver = new TestObserver<>();
     PublishSubject<String> subject = PublishSubject.create();
 
-    group.add(fooObserver.getTag(), null, subject, testObserver);
+    group.add(fooObserver.getTag(), fooObserver.getTag(), subject, testObserver);
     group.unsubscribe();
 
     subject.onNext("Roberto Gomez Bolanos");
@@ -215,7 +215,7 @@ public class ObservableGroupTest {
     ObservableGroup group = observableManager.newGroup();
     TestObserver<String> testObserver = new TestObserver<>();
     PublishSubject<String> subject = PublishSubject.create();
-    group.add(fooObserver.getTag(), null, subject, testObserver);
+    group.add(fooObserver.getTag(), fooObserver.getTag(), subject, testObserver);
     group.unsubscribe();
 
     subject.onNext("Hello World");
@@ -236,7 +236,7 @@ public class ObservableGroupTest {
     TestObserver<String> testObserver = new TestObserver<>();
     PublishSubject<String> subject = PublishSubject.create();
 
-    group.add(fooObserver.getTag(), null, subject, testObserver);
+    group.add(fooObserver.getTag(), fooObserver.getTag(), subject, testObserver);
     group.unsubscribe();
 
     subject.onError(new Exception("Exploded"));
@@ -255,7 +255,7 @@ public class ObservableGroupTest {
     ObservableGroup group = observableManager.newGroup();
     TestObserver<String> testObserver = new TestObserver<>();
     PublishSubject<String> subject = PublishSubject.create();
-    group.add(fooObserver.getTag(), null, subject, testObserver);
+    group.add(fooObserver.getTag(), fooObserver.getTag(), subject, testObserver);
     group.unsubscribe();
 
     subject.onNext("Hello World");
@@ -281,7 +281,7 @@ public class ObservableGroupTest {
     PublishSubject<String> subject = PublishSubject.create();
     TestObserver<String> testObserver = new TestObserver<>();
 
-    group2.add(fooObserver.getTag(), null, subject, testObserver);
+    group2.add(fooObserver.getTag(), fooObserver.getTag(), subject, testObserver);
     group.unsubscribe();
 
     subject.onNext("Gremio Foot-ball Porto Alegrense");
@@ -299,7 +299,7 @@ public class ObservableGroupTest {
     PublishSubject<String> subject = PublishSubject.create();
     TestObserver<String> testObserver = new TestObserver<>();
 
-    group.add(fooObserver.getTag(), null, subject, testObserver);
+    group.add(fooObserver.getTag(), fooObserver.getTag(), subject, testObserver);
     observableManager.destroy(group);
 
     subject.onNext("Gremio Foot-ball Porto Alegrense");
@@ -317,8 +317,8 @@ public class ObservableGroupTest {
     PublishSubject<String> subject2 = PublishSubject.create();
     TestObserver<String> testSubscriber2 = new TestObserver<>();
 
-    group.add(fooObserver.getTag(), null, subject1, testSubscriber1);
-    group2.add(barObserver.getTag(), null, subject2, testSubscriber2);
+    group.add(fooObserver.getTag(), fooObserver.getTag(), subject1, testSubscriber1);
+    group2.add(barObserver.getTag(), barObserver.getTag(), subject2, testSubscriber2);
     group.unsubscribe();
 
     subject1.onNext("Florinda Mesa");
@@ -337,7 +337,7 @@ public class ObservableGroupTest {
     TestObserver<String> testSubscriber1 = new TestObserver<>();
     TestObserver<String> testSubscriber2 = new TestObserver<>();
 
-    group.add(fooObserver.getTag(), null, subject, testSubscriber1);
+    group.add(fooObserver.getTag(), fooObserver.getTag(), subject, testSubscriber1);
     group.observable(fooObserver).subscribe(testSubscriber2);
 
     subject.onNext("Ruben Aguirre");
@@ -356,8 +356,8 @@ public class ObservableGroupTest {
     PublishSubject<String> subject2 = PublishSubject.create();
     TestObserver<String> testSubscriber2 = new TestObserver<>();
 
-    group.add(fooObserver.getTag(), null, subject1, testSubscriber1);
-    group.add(barObserver.getTag(), null, subject2, testSubscriber2);
+    group.add(fooObserver.getTag(), fooObserver.getTag(), subject1, testSubscriber1);
+    group.add(barObserver.getTag(), barObserver.getTag(), subject2, testSubscriber2);
     group.unsubscribe();
 
     subject1.onNext("Chespirito");
@@ -377,7 +377,7 @@ public class ObservableGroupTest {
     PublishSubject<String> subject = PublishSubject.create();
 
     group.lock();
-    group.add(fooObserver.getTag(), null, subject, testObserver);
+    group.add(fooObserver.getTag(), fooObserver.getTag(), subject, testObserver);
 
     subject.onNext("Chespirito");
     subject.onCompleted();
@@ -393,7 +393,7 @@ public class ObservableGroupTest {
     PublishSubject<String> subject = PublishSubject.create();
 
     group.lock();
-    group.add(fooObserver.getTag(), null, subject, testObserver);
+    group.add(fooObserver.getTag(), fooObserver.getTag(), subject, testObserver);
 
     subject.onNext("Chespirito");
     subject.onCompleted();
@@ -411,7 +411,7 @@ public class ObservableGroupTest {
     TestObserver<String> testObserver = new TestObserver<>();
     PublishSubject<String> subject = PublishSubject.create();
 
-    group.add(fooObserver.getTag(), null, subject, testObserver);
+    group.add(fooObserver.getTag(), fooObserver.getTag(), subject, testObserver);
     group.lock();
 
     subject.onNext("Chespirito");
@@ -430,7 +430,7 @@ public class ObservableGroupTest {
     TestObserver<String> testObserver = new TestObserver<>();
     PublishSubject<String> subject = PublishSubject.create();
 
-    group.add(fooObserver.getTag(), null, subject, testObserver);
+    group.add(fooObserver.getTag(), fooObserver.getTag(), subject, testObserver);
     group.lock();
     group.unsubscribe();
 

--- a/rxgroups/src/test/java/com/airbnb/rxgroups/ObservableGroupTest.java
+++ b/rxgroups/src/test/java/com/airbnb/rxgroups/ObservableGroupTest.java
@@ -518,31 +518,6 @@ public class ObservableGroupTest {
     observer1.assertValue("Hello World 1");
   }
 
-  /**
-   * The same observable tag can be used so long as it is associated with a different observer tag.
-   */
-  @Test public void testCancelAndRemoveAllWithTag() {
-    ObservableGroup group = observableManager.newGroup();
-    PublishSubject<String> observable1 = PublishSubject.create();
-    TestObserver<String> observer1 = new TestObserver<>();
-    TestObserver<String> observer2 = new TestObserver<>();
-    String sharedObservableTag = "sharedTag";
-    group.add(fooObserver.getTag(), sharedObservableTag, observable1, observer1);
-    group.add(barObserver.getTag(), sharedObservableTag, observable1, observer2);
-
-    assertThat(group.subscription(fooObserver, sharedObservableTag).isCancelled()).isFalse();
-    assertThat(group.hasObservables(fooObserver)).isTrue();
-
-    assertThat(group.subscription(barObserver, sharedObservableTag).isCancelled()).isFalse();
-    assertThat(group.hasObservables(barObserver)).isTrue();
-
-    group.cancelAndRemoveAllWithTag(sharedObservableTag);
-
-    assertThat(group.hasObservables(fooObserver)).isFalse();
-    assertThat(group.hasObservables(barObserver)).isFalse();
-
-  }
-
   @Test public void testCancelAndReAddSubscription() {
     ObservableGroup group = observableManager.newGroup();
     group.add(fooObserver.getTag(), fooObserver.getTag(), PublishSubject.<String>create(),

--- a/rxgroups/src/test/java/com/airbnb/rxgroups/ObservableGroupTest.java
+++ b/rxgroups/src/test/java/com/airbnb/rxgroups/ObservableGroupTest.java
@@ -558,5 +558,4 @@ public class ObservableGroupTest {
     assertThat(group.subscription(fooObserver).isCancelled()).isFalse();
   }
 
-
 }


### PR DESCRIPTION
As I prepare AirRequest for a 1.0 port, I realized that the new dual tag system partially supported having an observable with multiple subscribers. 

i.e:

```
class Main {
  Observable source = Observable.just("helloWorld);
  AutoResubscribringObserver one;
  AutoResubscribingObserver two;

  public void init() {
   source.transform(one, "source').subscribe(one);
   source.transform(two, "source").subscribe(two);
  }
}
```

now works because we will store `one -> "source"` and `two -> "source"`. Generally, this seems like a useful change.

This updates some of the docs to make this behavior more clear. 

Also, a cosmetic change. In the convenience case of 

` source.transform(one).subscribe(one);`

will store `one -> Main__one` instead of `one -> null`.

I discovered this because AirRequest supports the behavior of cancelling a request (observable) with just the (observable) tag. This becomes more complicated because this tag may now be associated with _multiple_ observers. So I added `cancelAndRemoveAllWithTag` to clearly communicate this.

Now, I don't necessarily think we will use this behavior internally -- and don't anticipate using it when I migrate to 1.0 internally. Our observables tags are currently unique within a group, and will remain that way. However, I can see how it would be useful if an observable was multicasted.

```
ConnectableObservable connectbleSource = source.publish();
connectableSource.map(-> some map).transform(one, "connectbleSource").subscribe(one);
connectableSource.filter().transform(two, "connectableSource").subscribe(two, "connectbleSource");
connectableSource.publish()

// later
group.cancelAndRemoveAllWithTag("connectedSource")
```
 would unsubscribe everything attached to `connectableSource` in one shot.

Alternatively, of we choose not to support this, we would have to check that each obseravbleTag is globally unique within the group, and `cancelAndRemove` the duplicate.

TODO:

- [x] Add tests for new behavior