### PR TITLE
gradle updated, rx updated, create instead fromEmitter

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,16 +3,18 @@
 buildscript {
   repositories {
     jcenter()
+      google()
   }
   dependencies {
     classpath 'com.bmuschko:gradle-nexus-plugin:2.3.1'
-    classpath 'com.android.tools.build:gradle:2.2.3'
+    classpath 'com.android.tools.build:gradle:3.1.2'
   }
 }
 
 allprojects {
   repositories {
     jcenter()
+    google()
   }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sat Aug 27 18:56:48 PDT 2016
+#Thu May 03 18:44:43 MSK 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip

--- a/rxgroups-android/build.gradle
+++ b/rxgroups-android/build.gradle
@@ -2,12 +2,12 @@ apply plugin: 'com.android.library'
 apply from: 'gradle-maven-push.gradle'
 
 android {
-  compileSdkVersion 25
-  buildToolsVersion "25.0.2"
+  compileSdkVersion 27
+  buildToolsVersion "27.0.3"
 
   defaultConfig {
     minSdkVersion 16
-    targetSdkVersion 25
+    targetSdkVersion 27
   }
 }
 
@@ -16,7 +16,7 @@ dependencies {
   compile 'io.reactivex:rxandroid:1.2.1'
 
   testCompile "junit:junit:4.12"
-  testCompile 'org.mockito:mockito-core:1.10.19'
+  testCompile 'org.mockito:mockito-core:2.9.0'
   testCompile "org.hamcrest:hamcrest-integration:1.3"
   testCompile "org.hamcrest:hamcrest-core:1.3"
   testCompile "org.hamcrest:hamcrest-library:1.3"

--- a/rxgroups/build.gradle
+++ b/rxgroups/build.gradle
@@ -15,7 +15,7 @@ project.group = GROUP
 project.version = VERSION_NAME
 
 dependencies {
-  compile 'io.reactivex:rxjava:1.2.6'
+  compile 'io.reactivex:rxjava:1.3.7'
   compile 'com.google.code.findbugs:jsr305:3.0.0'
 
   testCompile 'junit:junit:4.12'

--- a/rxgroups/src/main/java/com/airbnb/rxgroups/GroupSubscriptionTransformer.java
+++ b/rxgroups/src/main/java/com/airbnb/rxgroups/GroupSubscriptionTransformer.java
@@ -35,7 +35,7 @@ class GroupSubscriptionTransformer<T> implements Observable.Transformer<T, T> {
   }
 
   @Override public Observable<T> call(final Observable<T> observable) {
-    return Observable.fromEmitter(new Action1<Emitter<T>>() {
+    return Observable.create(new Action1<Emitter<T>>() {
       @Override public void call(final Emitter<T> emitter) {
         group.add(tag, observable, new Observer<T>() {
           @Override public void onCompleted() {

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -1,13 +1,13 @@
 apply plugin: 'com.android.application'
 
 android {
-  compileSdkVersion 25
-  buildToolsVersion "25.0.2"
+  compileSdkVersion 27
+  buildToolsVersion "27.0.3"
 
   defaultConfig {
     applicationId "com.airbnb.rxgroups"
     minSdkVersion 16
-    targetSdkVersion 25
+    targetSdkVersion 27
     versionCode 1
     versionName "1.0"
   }
@@ -24,9 +24,9 @@ android {
 }
 
 dependencies {
-  compile project(':rxgroups-android')
-  compile 'io.reactivex:rxandroid:1.2.0'
-  compile 'com.android.support:appcompat-v7:25.1.1'
-  compile 'com.android.support:design:25.1.1'
-  testCompile 'junit:junit:4.12'
+  implementation project(':rxgroups-android')
+  implementation 'io.reactivex:rxandroid:1.2.1'
+  implementation 'com.android.support:appcompat-v7:27.1.1'
+  implementation 'com.android.support:design:27.1.1'
+  testImplementation 'junit:junit:4.12'
 }


### PR DESCRIPTION
Update for the gradle and RxJava 1.0 version (deprecated :()