### PR TITLE
Completable interface added

### DIFF
--- a/rxgroups-annotation-test/src/test/java/com/airbnb/rxgroups/ResubscriptionProcessorTest.java
+++ b/rxgroups-annotation-test/src/test/java/com/airbnb/rxgroups/ResubscriptionProcessorTest.java
@@ -119,7 +119,7 @@ public class ResubscriptionProcessorTest {
         .withCompilerOptions("-Xlint:-processing")
         .processedWith(new ResubscriptionProcessor())
         .failsToCompile()
-        .withErrorContaining("AutoResubscribe annotation may only be on interface com.airbnb.rxgroups.TaggedObserver types.");
+        .withErrorContaining("AutoResubscribe annotation may only be on interface com.airbnb.rxgroups.TaggedObserver (or interface com.airbnb.rxgroups.CompletableTaggedObserver) types.");
   }
 
   @Test public void plainObserverFails_autoTag() throws Exception {
@@ -137,7 +137,6 @@ public class ResubscriptionProcessorTest {
   @Test public void taggedObserverFails_autoTag() throws Exception {
     JavaFileObject source = JavaFileObjects.forResource("TaggedObserver_Fail_AutoTag.java");
 
-
     Truth.assertAbout(JavaSourceSubjectFactory.javaSource()).that(source)
         .withCompilerOptions("-Xlint:-processing")
         .processedWith(new ResubscriptionProcessor())
@@ -145,9 +144,18 @@ public class ResubscriptionProcessorTest {
         .withErrorContaining("AutoTag annotation may only be on interface com.airbnb.rxgroups.AutoTaggableObserver or class com.airbnb.rxgroups.AutoResubscribingObserver types.");
   }
 
+  @Test public void completableTaggedObserverFails_autoTag() throws Exception {
+    JavaFileObject source = JavaFileObjects.forResource("CompletableTaggedObserver_Fail_AutoTag.java");
+
+    Truth.assertAbout(JavaSourceSubjectFactory.javaSource()).that(source)
+            .withCompilerOptions("-Xlint:-processing")
+            .processedWith(new ResubscriptionProcessor())
+            .failsToCompile()
+            .withErrorContaining("AutoTag annotation may only be on interface com.airbnb.rxgroups.AutoTaggableObserver or class com.airbnb.rxgroups.AutoResubscribingObserver types.");
+  }
+
   @Test public void privateObserver_fail() throws Exception {
     JavaFileObject source = JavaFileObjects.forResource("AutoResubscribingObserver_Fail_Private.java");
-
 
     Truth.assertAbout(JavaSourceSubjectFactory.javaSource()).that(source)
         .withCompilerOptions("-Xlint:-processing")

--- a/rxgroups-annotation-test/src/test/resources/CompletableTaggedObserver_Fail_AutoTag.java
+++ b/rxgroups-annotation-test/src/test/resources/CompletableTaggedObserver_Fail_AutoTag.java
@@ -1,0 +1,30 @@
+package test;
+
+import com.airbnb.rxgroups.AutoTag;
+import com.airbnb.rxgroups.TaggedObserver;
+import com.airbnb.rxgroups.CompletableTaggedObserver;
+
+public class CompletableTaggedObserver_Fail_AutoTag {
+    @AutoTag
+    public CompletableTaggedObserver<Object> taggedObserver = new CompletableTaggedObserver<Object>() {
+        @Override
+        public String getTag() {
+            return "stableTag";
+        }
+
+        @Override
+        public void onCompleted() {
+
+        }
+
+        @Override
+        public void onError(Throwable e) {
+
+        }
+
+        @Override
+        public void onNext(Object o) {
+
+        }
+    };
+}

--- a/rxgroups-annotation-test/src/test/resources/CompletableTaggedObserver_Pass_AutoResubscribe.java
+++ b/rxgroups-annotation-test/src/test/resources/CompletableTaggedObserver_Pass_AutoResubscribe.java
@@ -1,0 +1,31 @@
+package test;
+
+import com.airbnb.rxgroups.AutoResubscribe;
+import com.airbnb.rxgroups.TaggedObserver;
+
+import io.reactivex.disposables.Disposable;
+
+public class CompletableTaggedObserver_Pass_AutoResubscribe {
+    @AutoResubscribe
+    public TaggedObserver<Object> taggedObserver = new TaggedObserver<Object>() {
+        @Override public String getTag() {
+            return "stableTag";
+        }
+
+        @Override public void onComplete() {
+
+        }
+
+        @Override public void onError(Throwable e) {
+
+        }
+
+        @Override public void onNext(Object o) {
+
+        }
+
+        @Override public void onSubscribe(Disposable d) {
+
+        }
+    };
+}

--- a/rxgroups-processor/src/main/java/com/airbnb/rxgroups/processor/ProcessorUtils.java
+++ b/rxgroups-processor/src/main/java/com/airbnb/rxgroups/processor/ProcessorUtils.java
@@ -1,8 +1,10 @@
 package com.airbnb.rxgroups.processor;
 
 
+import com.airbnb.rxgroups.AutoResubscribingCompletable;
 import com.airbnb.rxgroups.AutoResubscribingObserver;
 import com.airbnb.rxgroups.AutoTaggableObserver;
+import com.airbnb.rxgroups.CompletableTaggedObserver;
 import com.airbnb.rxgroups.TaggedObserver;
 
 import javax.lang.model.element.Element;
@@ -12,27 +14,43 @@ import javax.lang.model.util.Types;
 
 class ProcessorUtils {
 
-  static boolean isResubscribingObserver(Element observerFieldElement, Types typeUtil, Elements
-          elementUtil) {
-    final TypeMirror autoResubscribingTypeMirror = elementUtil.getTypeElement(
-            AutoResubscribingObserver.class.getCanonicalName()).asType();
-    return typeUtil.isAssignable(observerFieldElement.asType(), typeUtil.erasure(
-            autoResubscribingTypeMirror));
-  }
+    static boolean isResubscribingObserver(Element observerFieldElement, Types typeUtil, Elements
+            elementUtil) {
+        final TypeMirror autoResubscribingTypeMirror = elementUtil.getTypeElement(
+                AutoResubscribingObserver.class.getCanonicalName()).asType();
+        return typeUtil.isAssignable(observerFieldElement.asType(), typeUtil.erasure(
+                autoResubscribingTypeMirror));
+    }
 
-  static boolean isTaggedObserver(Element observerFieldElement, Types typeUtil, Elements
-      elementUtil) {
-    final TypeMirror autoResubscribingTypeMirror = elementUtil.getTypeElement(
-        TaggedObserver.class.getCanonicalName()).asType();
-    return typeUtil.isAssignable(observerFieldElement.asType(), typeUtil.erasure(
-        autoResubscribingTypeMirror));
-  }
+    static boolean isTaggedObserver(Element observerFieldElement, Types typeUtil, Elements
+            elementUtil) {
+        final TypeMirror autoResubscribingTypeMirror = elementUtil.getTypeElement(
+                TaggedObserver.class.getCanonicalName()).asType();
+        return typeUtil.isAssignable(observerFieldElement.asType(), typeUtil.erasure(
+                autoResubscribingTypeMirror));
+    }
 
-  static boolean isAutoTaggable(Element observerFieldElement, Types typeUtil, Elements
-      elementUtil) {
-    final TypeMirror autoResubscribingTypeMirror = elementUtil.getTypeElement(
-        AutoTaggableObserver.class.getCanonicalName()).asType();
-    return typeUtil.isAssignable(observerFieldElement.asType(), typeUtil.erasure(
-        autoResubscribingTypeMirror));
-  }
+    static boolean isResubscribingCompletable(Element observerFieldElement, Types typeUtil, Elements
+            elementUtil) {
+        final TypeMirror autoResubscribingTypeMirror = elementUtil.getTypeElement(
+                AutoResubscribingCompletable.class.getCanonicalName()).asType();
+        return typeUtil.isAssignable(observerFieldElement.asType(), typeUtil.erasure(
+                autoResubscribingTypeMirror));
+    }
+
+    static boolean isCompletableTaggedObserver(Element observerFieldElement, Types typeUtil, Elements
+            elementUtil) {
+        final TypeMirror autoResubscribingTypeMirror = elementUtil.getTypeElement(
+                CompletableTaggedObserver.class.getCanonicalName()).asType();
+        return typeUtil.isAssignable(observerFieldElement.asType(), typeUtil.erasure(
+                autoResubscribingTypeMirror));
+    }
+
+    static boolean isAutoTaggable(Element observerFieldElement, Types typeUtil, Elements
+            elementUtil) {
+        final TypeMirror autoResubscribingTypeMirror = elementUtil.getTypeElement(
+                AutoTaggableObserver.class.getCanonicalName()).asType();
+        return typeUtil.isAssignable(observerFieldElement.asType(), typeUtil.erasure(
+                autoResubscribingTypeMirror));
+    }
 }

--- a/rxgroups-processor/src/main/java/com/airbnb/rxgroups/processor/ResubscriptionProcessor.java
+++ b/rxgroups-processor/src/main/java/com/airbnb/rxgroups/processor/ResubscriptionProcessor.java
@@ -1,10 +1,12 @@
 package com.airbnb.rxgroups.processor;
 
 import com.airbnb.rxgroups.AutoResubscribe;
+import com.airbnb.rxgroups.AutoResubscribingCompletable;
 import com.airbnb.rxgroups.AutoResubscribingObserver;
 import com.airbnb.rxgroups.AutoTag;
 import com.airbnb.rxgroups.AutoTaggableObserver;
 import com.airbnb.rxgroups.BaseObservableResubscriber;
+import com.airbnb.rxgroups.CompletableTaggedObserver;
 import com.airbnb.rxgroups.ObservableGroup;
 import com.airbnb.rxgroups.TaggedObserver;
 import com.google.auto.service.AutoService;
@@ -39,6 +41,7 @@ import javax.lang.model.util.Types;
 import javax.tools.Diagnostic;
 
 import static com.airbnb.rxgroups.processor.ResubscriptionProcessor.ObserverType.AUTO_RESUBSCRIBE_OBSERVER;
+import static com.airbnb.rxgroups.processor.ResubscriptionProcessor.ObserverType.TAGGED_COMPLETABLE;
 import static com.airbnb.rxgroups.processor.ResubscriptionProcessor.ObserverType.TAGGED_OBSERVER;
 import static javax.lang.model.element.ElementKind.CLASS;
 import static javax.lang.model.element.Modifier.PRIVATE;
@@ -47,269 +50,272 @@ import static javax.lang.model.element.Modifier.STATIC;
 
 @AutoService(Processor.class)
 public class ResubscriptionProcessor extends AbstractProcessor {
-  private Filer filer;
-  private Messager messager;
-  private Elements elementUtils;
-  private Types typeUtils;
-  private final List<Exception> loggedExceptions = new ArrayList<>();
+    private Filer filer;
+    private Messager messager;
+    private Elements elementUtils;
+    private Types typeUtils;
+    private final List<Exception> loggedExceptions = new ArrayList<>();
 
-  @Override
-  public synchronized void init(ProcessingEnvironment processingEnv) {
-    super.init(processingEnv);
-    filer = processingEnv.getFiler();
-    messager = processingEnv.getMessager();
-    elementUtils = processingEnv.getElementUtils();
-    typeUtils = processingEnv.getTypeUtils();
-  }
-
-  @Override
-  public Set<String> getSupportedAnnotationTypes() {
-    return ImmutableSet.of(AutoResubscribe.class.getCanonicalName(),
-        AutoTag.class.getCanonicalName());
-  }
-
-  @Override
-  public SourceVersion getSupportedSourceVersion() {
-    return SourceVersion.latestSupported();
-  }
-
-  @Override
-  public boolean process(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {
-    LinkedHashMap<TypeElement, ClassToGenerateInfo> modelClassMap = new LinkedHashMap<>();
-    for (Element observer : roundEnv.getElementsAnnotatedWith(AutoResubscribe.class)) {
-      try {
-        processObserver(observer, modelClassMap, AutoResubscribe.class);
-      } catch (Exception e) {
-        logError(e);
-      }
+    @Override
+    public synchronized void init(ProcessingEnvironment processingEnv) {
+        super.init(processingEnv);
+        filer = processingEnv.getFiler();
+        messager = processingEnv.getMessager();
+        elementUtils = processingEnv.getElementUtils();
+        typeUtils = processingEnv.getTypeUtils();
     }
 
-    for (Element observer : roundEnv.getElementsAnnotatedWith(AutoTag.class)) {
-      try {
-        processObserver(observer, modelClassMap, AutoTag.class);
-      } catch (Exception e) {
-        logError(e);
-      }
+    @Override
+    public Set<String> getSupportedAnnotationTypes() {
+        return ImmutableSet.of(AutoResubscribe.class.getCanonicalName(),
+                AutoTag.class.getCanonicalName());
     }
 
-    for (Map.Entry<TypeElement, ClassToGenerateInfo> modelEntry : modelClassMap.entrySet()) {
-      try {
-        generateClass(modelEntry.getValue());
-      } catch (Exception e) {
-        logError(e);
-      }
+    @Override
+    public SourceVersion getSupportedSourceVersion() {
+        return SourceVersion.latestSupported();
     }
 
-    if (roundEnv.processingOver()) {
-      for (Exception loggedException : loggedExceptions) {
-        messager.printMessage(Diagnostic.Kind.ERROR, loggedException.toString());
-      }
+    @Override
+    public boolean process(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {
+        LinkedHashMap<TypeElement, ClassToGenerateInfo> modelClassMap = new LinkedHashMap<>();
+        for (Element observer : roundEnv.getElementsAnnotatedWith(AutoResubscribe.class)) {
+            try {
+                processObserver(observer, modelClassMap, AutoResubscribe.class);
+            } catch (Exception e) {
+                logError(e);
+            }
+        }
+
+        for (Element observer : roundEnv.getElementsAnnotatedWith(AutoTag.class)) {
+            try {
+                processObserver(observer, modelClassMap, AutoTag.class);
+            } catch (Exception e) {
+                logError(e);
+            }
+        }
+
+        for (Map.Entry<TypeElement, ClassToGenerateInfo> modelEntry : modelClassMap.entrySet()) {
+            try {
+                generateClass(modelEntry.getValue());
+            } catch (Exception e) {
+                logError(e);
+            }
+        }
+
+        if (roundEnv.processingOver()) {
+            for (Exception loggedException : loggedExceptions) {
+                messager.printMessage(Diagnostic.Kind.ERROR, loggedException.toString());
+            }
+        }
+
+        // Let other processors access our annotations as well
+        return false;
     }
 
-    // Let other processors access our annotations as well
-    return false;
-  }
+    private void processObserver(Element observer, LinkedHashMap<TypeElement, ClassToGenerateInfo>
+            info, Class<? extends Annotation> annotationClass) {
+        validateObserverField(observer, annotationClass);
+        TypeElement enclosingClass = (TypeElement) observer.getEnclosingElement();
+        ClassToGenerateInfo targetClass = getOrCreateTargetClass(info, enclosingClass);
 
-  private void processObserver(Element observer, LinkedHashMap<TypeElement, ClassToGenerateInfo>
-          info, Class<? extends Annotation> annotationClass) {
-    validateObserverField(observer, annotationClass);
-    TypeElement enclosingClass = (TypeElement) observer.getEnclosingElement();
-    ClassToGenerateInfo targetClass = getOrCreateTargetClass(info, enclosingClass);
+        String observerName = observer.getSimpleName().toString();
 
-    String observerName = observer.getSimpleName().toString();
+        boolean isAutoResubscribing =
+                ProcessorUtils.isResubscribingObserver(observer, typeUtils, elementUtils);
+        boolean isCompletable = ProcessorUtils.isCompletableTaggedObserver(observer, typeUtils, elementUtils);
+        ObserverType observerType = isAutoResubscribing ? AUTO_RESUBSCRIBE_OBSERVER : isCompletable ? TAGGED_COMPLETABLE : TAGGED_OBSERVER;
+        boolean isAutoTaggable = ProcessorUtils.isAutoTaggable(observer, typeUtils, elementUtils);
+        boolean shouldAutoResubscribe = annotationClass == AutoResubscribe.class;
+        String customTag = getCustomTag(observer, annotationClass);
 
-    boolean isAutoResubscribing =
-        ProcessorUtils.isResubscribingObserver(observer, typeUtils, elementUtils);
-    ObserverType observerType = isAutoResubscribing ? AUTO_RESUBSCRIBE_OBSERVER : TAGGED_OBSERVER;
-    boolean isAutoTaggable = ProcessorUtils.isAutoTaggable(observer, typeUtils, elementUtils);
-    boolean shouldAutoResubscribe = annotationClass == AutoResubscribe.class;
-    String customTag = getCustomTag(observer, annotationClass);
-
-    targetClass.addObserver(observerName, new ObserverInfo(observerType, customTag, isAutoTaggable,
-        shouldAutoResubscribe));
-  }
-
-  private String getCustomTag(Element observer, Class<? extends Annotation> annotationClass) {
-    String customTag = "";
-    if (annotationClass == AutoResubscribe.class) {
-      customTag = ((AutoResubscribe)observer.getAnnotation(annotationClass)).customTag();
-    }
-    else if (annotationClass == AutoTag.class) {
-      customTag = ((AutoTag)observer.getAnnotation(annotationClass)).customTag();
-    }
-    return customTag;
-  }
-
-  private void validateObserverField(Element observerFieldElement,
-                                     Class<? extends Annotation> annotationClass) {
-
-    TypeElement enclosingClass = (TypeElement) observerFieldElement.getEnclosingElement();
-
-    if (annotationClass == AutoResubscribe.class
-        && !ProcessorUtils.isTaggedObserver(observerFieldElement, typeUtils, elementUtils)) {
-      logError("%s annotation may only be on %s types. (class: %s, field: %s)",
-              annotationClass.getSimpleName(), TaggedObserver.class,
-              enclosingClass.getSimpleName(), observerFieldElement.getSimpleName());
+        targetClass.addObserver(observerName, new ObserverInfo(observerType, customTag, isAutoTaggable,
+                shouldAutoResubscribe));
     }
 
-    if (annotationClass == AutoTag.class &&
-        !(ProcessorUtils.isAutoTaggable(observerFieldElement, typeUtils, elementUtils) ||
-            ProcessorUtils.isResubscribingObserver(observerFieldElement, typeUtils, elementUtils))) {
-      logError("%s annotation may only be on %s or %s types. (class: %s, field: %s)",
-          annotationClass.getSimpleName(), AutoTaggableObserver.class, AutoResubscribingObserver.class,
-          enclosingClass.getSimpleName(), observerFieldElement.getSimpleName());
+    private String getCustomTag(Element observer, Class<? extends Annotation> annotationClass) {
+        String customTag = "";
+        if (annotationClass == AutoResubscribe.class) {
+            customTag = ((AutoResubscribe) observer.getAnnotation(annotationClass)).customTag();
+        } else if (annotationClass == AutoTag.class) {
+            customTag = ((AutoTag) observer.getAnnotation(annotationClass)).customTag();
+        }
+        return customTag;
     }
 
-    // Verify method modifiers.
-    Set<Modifier> modifiers = observerFieldElement.getModifiers();
-    if (modifiers.contains(PRIVATE) || modifiers.contains(STATIC)) {
-      logError(
-              "%s annotations must not be on private or static fields. (class: %s, field: "
-                      + "%s)",
-              annotationClass.getSimpleName(),
-              enclosingClass.getSimpleName(), observerFieldElement.getSimpleName());
+    private void validateObserverField(Element observerFieldElement,
+                                       Class<? extends Annotation> annotationClass) {
+
+        TypeElement enclosingClass = (TypeElement) observerFieldElement.getEnclosingElement();
+
+        if (annotationClass == AutoResubscribe.class
+                && !(ProcessorUtils.isTaggedObserver(observerFieldElement, typeUtils, elementUtils) ||
+                ProcessorUtils.isCompletableTaggedObserver(observerFieldElement, typeUtils, elementUtils))) {
+            logError("%s annotation may only be on %s (or %s) types. (class: %s, field: %s)",
+                    annotationClass.getSimpleName(), TaggedObserver.class, CompletableTaggedObserver.class,
+                    enclosingClass.getSimpleName(), observerFieldElement.getSimpleName());
+        }
+
+        if (annotationClass == AutoTag.class &&
+                !(ProcessorUtils.isAutoTaggable(observerFieldElement, typeUtils, elementUtils) ||
+                        ProcessorUtils.isResubscribingObserver(observerFieldElement, typeUtils, elementUtils) ||
+                        ProcessorUtils.isResubscribingCompletable(observerFieldElement, typeUtils, elementUtils))) {
+            logError("%s annotation may only be on %s or %s or $s types. (class: %s, field: %s)",
+                    annotationClass.getSimpleName(), AutoTaggableObserver.class, AutoResubscribingObserver.class, AutoResubscribingCompletable.class,
+                    enclosingClass.getSimpleName(), observerFieldElement.getSimpleName());
+        }
+
+        // Verify method modifiers.
+        Set<Modifier> modifiers = observerFieldElement.getModifiers();
+        if (modifiers.contains(PRIVATE) || modifiers.contains(STATIC)) {
+            logError(
+                    "%s annotations must not be on private or static fields. (class: %s, field: "
+                            + "%s)",
+                    annotationClass.getSimpleName(),
+                    enclosingClass.getSimpleName(), observerFieldElement.getSimpleName());
+        }
+
+        // Nested classes must be static
+        if (enclosingClass.getNestingKind().isNested()) {
+            if (!enclosingClass.getModifiers().contains(STATIC)) {
+                logError(
+                        "Nested classes with %s annotations must be static. (class: %s, field: %s)",
+                        annotationClass.getSimpleName(),
+                        enclosingClass.getSimpleName(), observerFieldElement.getSimpleName());
+            }
+        }
+
+        // Verify containing type.
+        if (enclosingClass.getKind() != CLASS) {
+            logError("%s annotations may only be contained in classes. (class: %s, field: %s)",
+                    annotationClass.getSimpleName(),
+                    enclosingClass.getSimpleName(), observerFieldElement.getSimpleName());
+        }
+
+        // Verify containing class visibility is not private.
+        if (enclosingClass.getModifiers().contains(PRIVATE)) {
+            logError("%s annotations may not be contained in private classes. (class: %s, "
+                            + "field: %s)",
+                    annotationClass.getSimpleName(),
+                    enclosingClass.getSimpleName(), observerFieldElement.getSimpleName());
+        }
     }
 
-    // Nested classes must be static
-    if (enclosingClass.getNestingKind().isNested()) {
-      if (!enclosingClass.getModifiers().contains(STATIC)) {
-        logError(
-                "Nested classes with %s annotations must be static. (class: %s, field: %s)",
-                annotationClass.getSimpleName(),
-                enclosingClass.getSimpleName(), observerFieldElement.getSimpleName());
-      }
+    private ClassToGenerateInfo getOrCreateTargetClass(
+            Map<TypeElement, ClassToGenerateInfo> modelClassMap, TypeElement classElement) {
+
+        ClassToGenerateInfo classToGenerateInfo = modelClassMap.get(classElement);
+
+        if (classToGenerateInfo == null) {
+            ClassName generatedClassName = getGeneratedClassName(classElement);
+            classToGenerateInfo = new ClassToGenerateInfo(classElement, generatedClassName);
+            modelClassMap.put(classElement, classToGenerateInfo);
+        }
+
+        return classToGenerateInfo;
     }
 
-    // Verify containing type.
-    if (enclosingClass.getKind() != CLASS) {
-      logError("%s annotations may only be contained in classes. (class: %s, field: %s)",
-              annotationClass.getSimpleName(),
-              enclosingClass.getSimpleName(), observerFieldElement.getSimpleName());
+    private ClassName getGeneratedClassName(TypeElement classElement) {
+        String packageName = elementUtils.getPackageOf(classElement).getQualifiedName().toString();
+
+        int packageLen = packageName.length() + 1;
+        String className =
+                classElement.getQualifiedName().toString().substring(packageLen).replace('.', '$');
+
+        return ClassName.get(packageName, className + ProcessorHelper.GENERATED_CLASS_NAME_SUFFIX);
     }
 
-    // Verify containing class visibility is not private.
-    if (enclosingClass.getModifiers().contains(PRIVATE)) {
-      logError("%s annotations may not be contained in private classes. (class: %s, "
-                      + "field: %s)",
-              annotationClass.getSimpleName(),
-              enclosingClass.getSimpleName(), observerFieldElement.getSimpleName());
-    }
-  }
+    private void generateClass(ClassToGenerateInfo info) throws IOException {
+        TypeSpec generatedClass = TypeSpec.classBuilder(info.generatedClassName)
+                .superclass(BaseObservableResubscriber.class)
+                .addJavadoc("Generated file. Do not modify!")
+                .addModifiers(Modifier.PUBLIC)
+                .addMethod(generateConstructor(info))
+                .build();
 
-  private ClassToGenerateInfo getOrCreateTargetClass(
-          Map<TypeElement, ClassToGenerateInfo> modelClassMap, TypeElement classElement) {
-
-    ClassToGenerateInfo classToGenerateInfo = modelClassMap.get(classElement);
-
-    if (classToGenerateInfo == null) {
-      ClassName generatedClassName = getGeneratedClassName(classElement);
-      classToGenerateInfo = new ClassToGenerateInfo(classElement, generatedClassName);
-      modelClassMap.put(classElement, classToGenerateInfo);
+        JavaFile.builder(info.generatedClassName.packageName(), generatedClass)
+                .build()
+                .writeTo(filer);
     }
 
-    return classToGenerateInfo;
-  }
+    private MethodSpec generateConstructor(ClassToGenerateInfo info) {
+        MethodSpec.Builder builder = MethodSpec.constructorBuilder()
+                .addModifiers(PUBLIC)
+                .addParameter(ParameterSpec.builder(TypeName.get(info.originalClassName.asType())
+                        , "target").build())
+                .addParameter(ParameterSpec.builder(TypeName.get(ObservableGroup.class), "group")
+                        .build());
 
-  private ClassName getGeneratedClassName(TypeElement classElement) {
-    String packageName = elementUtils.getPackageOf(classElement).getQualifiedName().toString();
+        for (Map.Entry<String, ObserverInfo> observerNameAndType
+                : info.observerNamesToType.entrySet()) {
+            String observerName = observerNameAndType.getKey();
+            ObserverInfo observerInfo = observerNameAndType.getValue();
+            if (observerInfo.type == AUTO_RESUBSCRIBE_OBSERVER || observerInfo.autoTaggable) {
+                String tag = "".equals(observerInfo.customTag) ?
+                        info.originalClassName.getSimpleName().toString() + "_" + observerName
+                        : observerInfo.customTag;
+                builder.addStatement("setTag(target.$L, $S)", observerName, tag);
+            }
+            if (observerInfo.shouldAutoResubscribe) {
+                builder.addStatement("group.resubscribeAll(target.$L)", observerName);
+            }
+        }
 
-    int packageLen = packageName.length() + 1;
-    String className =
-            classElement.getQualifiedName().toString().substring(packageLen).replace('.', '$');
-
-    return ClassName.get(packageName, className + ProcessorHelper.GENERATED_CLASS_NAME_SUFFIX);
-  }
-
-  private void generateClass(ClassToGenerateInfo info) throws IOException {
-    TypeSpec generatedClass = TypeSpec.classBuilder(info.generatedClassName)
-            .superclass(BaseObservableResubscriber.class)
-            .addJavadoc("Generated file. Do not modify!")
-            .addModifiers(Modifier.PUBLIC)
-            .addMethod(generateConstructor(info))
-            .build();
-
-    JavaFile.builder(info.generatedClassName.packageName(), generatedClass)
-            .build()
-            .writeTo(filer);
-  }
-
-  private MethodSpec generateConstructor(ClassToGenerateInfo info) {
-    MethodSpec.Builder builder = MethodSpec.constructorBuilder()
-            .addModifiers(PUBLIC)
-            .addParameter(ParameterSpec.builder(TypeName.get(info.originalClassName.asType())
-                    , "target").build())
-            .addParameter(ParameterSpec.builder(TypeName.get(ObservableGroup.class), "group")
-                    .build());
-
-    for (Map.Entry<String, ObserverInfo> observerNameAndType
-        : info.observerNamesToType.entrySet()) {
-      String observerName = observerNameAndType.getKey();
-      ObserverInfo observerInfo = observerNameAndType.getValue();
-      if (observerInfo.type == AUTO_RESUBSCRIBE_OBSERVER || observerInfo.autoTaggable) {
-        String tag = "".equals(observerInfo.customTag) ?
-            info.originalClassName.getSimpleName().toString() + "_" + observerName
-            : observerInfo.customTag;
-        builder.addStatement("setTag(target.$L, $S)", observerName, tag);
-      }
-      if (observerInfo.shouldAutoResubscribe) {
-        builder.addStatement("group.resubscribeAll(target.$L)", observerName);
-      }
+        return builder.build();
     }
 
-    return builder.build();
-  }
-
-  private static class RxGroupsResubscriptionProcessorException extends Exception {
-    RxGroupsResubscriptionProcessorException(String message) {
-      super(message);
-    }
-  }
-
-  private void logError(String msg, Object... args) {
-    logError(new RxGroupsResubscriptionProcessorException(String.format(msg, args)));
-  }
-
-  enum ObserverType {
-    TAGGED_OBSERVER,
-    AUTO_RESUBSCRIBE_OBSERVER
-  }
-
-  private static class ObserverInfo {
-    final ObserverType type;
-    final String customTag;
-    final boolean autoTaggable;
-    final boolean shouldAutoResubscribe;
-
-    ObserverInfo(ObserverType type, String customTag, boolean autoTaggable,
-                 boolean shouldAutoResubscribe) {
-      this.type = type;
-      this.customTag = customTag;
-      this.autoTaggable = autoTaggable;
-      this.shouldAutoResubscribe = shouldAutoResubscribe;
-    }
-  }
-
-  /**
-   * Exceptions are caught and logged, and not printed until all processing is done. This allows
-   * generated classes to be created first and allows for easier to read compile time error
-   * messages.
-   */
-  private void logError(Exception e) {
-    loggedExceptions.add(e);
-  }
-
-  private static class ClassToGenerateInfo {
-    final Map<String, ObserverInfo> observerNamesToType = new LinkedHashMap<>();
-    private final TypeElement originalClassName;
-    private final ClassName generatedClassName;
-
-    public ClassToGenerateInfo(TypeElement originalClassName, ClassName generatedClassName) {
-      this.originalClassName = originalClassName;
-      this.generatedClassName = generatedClassName;
+    private static class RxGroupsResubscriptionProcessorException extends Exception {
+        RxGroupsResubscriptionProcessorException(String message) {
+            super(message);
+        }
     }
 
-    public void addObserver(String observerName, ObserverInfo type) {
-      observerNamesToType.put(observerName, type);
+    private void logError(String msg, Object... args) {
+        logError(new RxGroupsResubscriptionProcessorException(String.format(msg, args)));
     }
-  }
+
+    enum ObserverType {
+        TAGGED_OBSERVER,
+        TAGGED_COMPLETABLE,
+        AUTO_RESUBSCRIBE_OBSERVER
+    }
+
+    private static class ObserverInfo {
+        final ObserverType type;
+        final String customTag;
+        final boolean autoTaggable;
+        final boolean shouldAutoResubscribe;
+
+        ObserverInfo(ObserverType type, String customTag, boolean autoTaggable,
+                     boolean shouldAutoResubscribe) {
+            this.type = type;
+            this.customTag = customTag;
+            this.autoTaggable = autoTaggable;
+            this.shouldAutoResubscribe = shouldAutoResubscribe;
+        }
+    }
+
+    /**
+     * Exceptions are caught and logged, and not printed until all processing is done. This allows
+     * generated classes to be created first and allows for easier to read compile time error
+     * messages.
+     */
+    private void logError(Exception e) {
+        loggedExceptions.add(e);
+    }
+
+    private static class ClassToGenerateInfo {
+        final Map<String, ObserverInfo> observerNamesToType = new LinkedHashMap<>();
+        private final TypeElement originalClassName;
+        private final ClassName generatedClassName;
+
+        public ClassToGenerateInfo(TypeElement originalClassName, ClassName generatedClassName) {
+            this.originalClassName = originalClassName;
+            this.generatedClassName = generatedClassName;
+        }
+
+        public void addObserver(String observerName, ObserverInfo type) {
+            observerNamesToType.put(observerName, type);
+        }
+    }
 }

--- a/rxgroups/src/main/java/com/airbnb/rxgroups/AutoResubscribingCompletable.java
+++ b/rxgroups/src/main/java/com/airbnb/rxgroups/AutoResubscribingCompletable.java
@@ -1,0 +1,32 @@
+package com.airbnb.rxgroups;
+
+import io.reactivex.annotations.NonNull;
+import io.reactivex.disposables.Disposable;
+
+public abstract class AutoResubscribingCompletable<T> implements CompletableTaggedObserver<T> {
+
+    private String tag;
+
+    public final String getTag() {
+        return tag;
+    }
+
+    void setTag(String tag) {
+        this.tag = tag;
+    }
+
+    @Override
+    public void onComplete() {
+
+    }
+
+    @Override
+    public void onError(Throwable e) {
+
+    }
+
+    @Override
+    public void onSubscribe(@NonNull Disposable d) {
+
+    }
+}

--- a/rxgroups/src/main/java/com/airbnb/rxgroups/CompletableTaggedObserver.java
+++ b/rxgroups/src/main/java/com/airbnb/rxgroups/CompletableTaggedObserver.java
@@ -1,0 +1,7 @@
+package com.airbnb.rxgroups;
+
+import io.reactivex.CompletableObserver;
+
+public interface CompletableTaggedObserver<T> extends CompletableObserver {
+    String getTag();
+}


### PR DESCRIPTION
Due to the fact that  RxJava 2.0 throws exception if faces null values, we need to use Completable. This commit add's CompletableTaggedObserver useful for the API DELETE, REMOVE methods. 