### PR TITLE
Use concurrent hash map for group observers

### DIFF
--- a/rxgroups/src/main/java/com/airbnb/rxgroups/ObservableGroup.java
+++ b/rxgroups/src/main/java/com/airbnb/rxgroups/ObservableGroup.java
@@ -15,7 +15,6 @@
  */
 package com.airbnb.rxgroups;
 
-import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -133,7 +132,7 @@ public class ObservableGroup {
   Map<String, ManagedObservable<?>> getObservablesForObserver(String observerTag) {
     Map<String, ManagedObservable<?>> map = groupMap.get(observerTag);
     if (map == null) {
-      map = new HashMap<>();
+      map = new ConcurrentHashMap<>();
       groupMap.put(observerTag, map);
     }
     return map;


### PR DESCRIPTION
Fix for the following exception
```
java.util.ConcurrentModificationException`
        at java.util.HashMap$HashIterator.nextNode(HashMap.java:1441)
        at java.util.HashMap$ValueIterator.next(HashMap.java:1470)
        at com.airbnb.rxgroups.ObservableGroup.forAllObservables(ObservableGroup.java:182)
        at com.airbnb.rxgroups.ObservableGroup.unlock(ObservableGroup.java:216)
        at com.airbnb.rxgroups.GroupLifecycleManager.unlock(GroupLifecycleManager.java:210)
        at com.airbnb.rxgroups.GroupLifecycleManager.onResume(GroupLifecycleManager.java:197)
```
@rossbacher 